### PR TITLE
Preserve column names in aid_by and aid_anomaly_by macros

### DIFF
--- a/test/sql/macros/test_aid_anomaly_by.test
+++ b/test/sql/macros/test_aid_anomaly_by.test
@@ -49,11 +49,11 @@ SELECT COUNT(DISTINCT group_id) FROM aid_anomaly_by('test_anomaly_data', group_i
 ----
 3
 
-# TEST 4: Output has correct columns (group_id, order_value, and boolean flags)
+# TEST 4: Output has correct columns (preserves original column names + boolean flags)
 query TTTTTTT
 SELECT
     group_id IS NOT NULL AS has_group,
-    order_value IS NOT NULL AS has_order,
+    period IS NOT NULL AS has_order,
     stockout IS NOT NULL AS has_stockout,
     new_product IS NOT NULL AS has_new_product,
     obsolete_product IS NOT NULL AS has_obsolete,
@@ -73,12 +73,12 @@ A	6
 B	6
 C	6
 
-# TEST 6: order_value column preserves original data
+# TEST 6: period column preserves original data (column name preserved from input)
 query TI
-SELECT group_id, order_value
+SELECT group_id, period
 FROM aid_anomaly_by('test_anomaly_data', group_id, period, demand, NULL)
 WHERE group_id = 'A'
-ORDER BY order_value
+ORDER BY period
 LIMIT 3;
 ----
 A	1

--- a/test/sql/macros/test_aid_by.test
+++ b/test/sql/macros/test_aid_by.test
@@ -49,9 +49,9 @@ SELECT COUNT(*) FROM aid_by('grouped_demand', product_id, demand);
 ----
 2
 
-# TEST 3: Returns correct groups
+# TEST 3: Returns correct groups (column name preserved from input)
 query I
-SELECT COUNT(DISTINCT group_id) FROM aid_by('grouped_demand', product_id, demand);
+SELECT COUNT(DISTINCT product_id) FROM aid_by('grouped_demand', product_id, demand);
 ----
 2
 
@@ -59,10 +59,10 @@ SELECT COUNT(DISTINCT group_id) FROM aid_by('grouped_demand', product_id, demand
 # COLUMN STRUCTURE TESTS (16 columns)
 # =============================================================================
 
-# TEST 4: All columns exist and are accessible
+# TEST 4: All columns exist and are accessible (first column preserves input name)
 query IIIIIIIIIIIIIIII
 SELECT
-    group_id IS NOT NULL AS has_group_id,
+    product_id IS NOT NULL AS has_product_id,
     demand_type IS NOT NULL AS has_demand_type,
     is_intermittent IS NOT NULL AS has_is_intermittent,
     distribution IS NOT NULL AS has_distribution,
@@ -101,8 +101,8 @@ true
 
 # TEST 7: Grouped data correctly classifies each product
 query TT
-SELECT group_id, is_intermittent FROM aid_by('grouped_demand', product_id, demand)
-ORDER BY group_id;
+SELECT product_id, is_intermittent FROM aid_by('grouped_demand', product_id, demand)
+ORDER BY product_id;
 ----
 intermittent	true
 smooth	false
@@ -217,7 +217,7 @@ SELECT COUNT(*) FROM aid_by('single_obs', product_id, demand);
 
 # TEST 21: Single observation count is 1
 query II
-SELECT group_id, n_observations FROM aid_by('single_obs', product_id, demand) ORDER BY group_id;
+SELECT product_id, n_observations FROM aid_by('single_obs', product_id, demand) ORDER BY product_id;
 ----
 A	1
 B	1
@@ -226,9 +226,9 @@ B	1
 # ORDERING AND DETERMINISM TESTS
 # =============================================================================
 
-# TEST 22: Results are ordered by group_id
+# TEST 22: Results are ordered by group column (preserves input column name)
 query T
-SELECT group_id FROM aid_by('grouped_demand', product_id, demand);
+SELECT product_id FROM aid_by('grouped_demand', product_id, demand);
 ----
 intermittent
 smooth


### PR DESCRIPTION
## Summary
- `aid_by` and `aid_anomaly_by` macros now preserve the original column names passed by the user instead of renaming them to generic names like `group_id` and `order_value`
- Simplified `aid_anomaly_by` implementation using window functions instead of CTEs and JOINs
- Updated tests to verify column name preservation

## Test plan
- [x] Existing tests updated and passing
- [x] `aid_by('table', product_id, demand)` now returns `product_id` column instead of `group_id`
- [x] `aid_anomaly_by('table', group_id, period, demand)` now returns `group_id, period` instead of `group_id, order_value`

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)