### PR TITLE
feat: add FunctionDescription metadata to all public functions

### DIFF
--- a/src/aggregate_functions/aid_aggregate.cpp
+++ b/src/aggregate_functions/aid_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -382,13 +383,39 @@ void RegisterAidAggregateFunction(ExtensionLoader &loader) {
                                      AidAggCombine, AidAggFinalize, nullptr, AidAggBind, AidAggDestroy);
     aid_set.AddFunction(aid_map);
 
-    loader.RegisterFunction(aid_set);
+    {
+        CreateAggregateFunctionInfo info(std::move(aid_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+        FunctionDescription d1;
+        d1.description = "Classifies demand patterns (smooth, intermittent, erratic, lumpy) using Automatic Identification of Demand (AID).";
+        d1.examples = {"anofox_stats_aid_agg(y)"};
+        d1.categories = {"demand-classification"};
+        d1.parameter_names = {"y"};
+        d1.parameter_types = {LogicalType::DOUBLE};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description = "Classifies demand patterns using AID with a MAP of options (intermittent_threshold, outlier_method).";
+        d2.examples = {"anofox_stats_aid_agg(y, {'intermittent_threshold': 0.3})"};
+        d2.categories = {"demand-classification"};
+        d2.parameter_names = {"y", "options"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Short alias for AID
-    AggregateFunctionSet aid_alias("aid_agg");
-    aid_alias.AddFunction(aid_basic);
-    aid_alias.AddFunction(aid_map);
-    loader.RegisterFunction(aid_alias);
+    {
+        AggregateFunctionSet aid_alias("aid_agg");
+        aid_alias.AddFunction(aid_basic);
+        aid_alias.AddFunction(aid_map);
+        CreateAggregateFunctionInfo alias_info(std::move(aid_alias));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_aid_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 
     // AID Anomaly Detection
     AggregateFunctionSet aid_anomaly_set("anofox_stats_aid_anomaly_agg");
@@ -405,13 +432,39 @@ void RegisterAidAggregateFunction(ExtensionLoader &loader) {
         AidAnomalyAggFinalize, nullptr, AidAnomalyAggBind, AidAggDestroy);
     aid_anomaly_set.AddFunction(aid_anomaly_map);
 
-    loader.RegisterFunction(aid_anomaly_set);
+    {
+        CreateAggregateFunctionInfo info(std::move(aid_anomaly_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+        FunctionDescription d1;
+        d1.description = "Identifies anomalies in demand time series using the AID classification framework.";
+        d1.examples = {"anofox_stats_aid_anomaly_agg(y)"};
+        d1.categories = {"demand-classification"};
+        d1.parameter_names = {"y"};
+        d1.parameter_types = {LogicalType::DOUBLE};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description = "Identifies anomalies in demand time series using AID with a MAP of options (intermittent_threshold, outlier_method).";
+        d2.examples = {"anofox_stats_aid_anomaly_agg(y, {'outlier_method': 'iqr'})"};
+        d2.categories = {"demand-classification"};
+        d2.parameter_names = {"y", "options"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Short alias for AID anomaly
-    AggregateFunctionSet aid_anomaly_alias("aid_anomaly_agg");
-    aid_anomaly_alias.AddFunction(aid_anomaly_basic);
-    aid_anomaly_alias.AddFunction(aid_anomaly_map);
-    loader.RegisterFunction(aid_anomaly_alias);
+    {
+        AggregateFunctionSet aid_anomaly_alias("aid_anomaly_agg");
+        aid_anomaly_alias.AddFunction(aid_anomaly_basic);
+        aid_anomaly_alias.AddFunction(aid_anomaly_map);
+        CreateAggregateFunctionInfo alias_info(std::move(aid_anomaly_alias));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_aid_anomaly_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/alm_aggregate.cpp
+++ b/src/aggregate_functions/alm_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -410,12 +411,33 @@ void RegisterAlmAggregateFunction(ExtensionLoader &loader) {
         AlmAggCombine, AlmAggFinalize, nullptr, AlmAggBind, AlmAggDestroy);
     func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Fits an Additive Linear Model (ALM) and returns coefficients and fit statistics.";
+    d1.examples        = {"anofox_stats_alm_fit_agg(y, x, {'fit_intercept': true})"};
+    d1.categories      = {"regression"};
+    d1.parameter_names = {"y", "x", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Fits an Additive Linear Model (ALM) and returns coefficients and fit statistics.";
+    d2.examples        = {"anofox_stats_alm_fit_agg(y, x)"};
+    d2.categories      = {"regression"};
+    d2.parameter_names = {"y", "x"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
-    AggregateFunctionSet alias_set("alm_fit_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("alm_fit_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_alm_fit_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/alm_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/alm_fit_predict_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -563,15 +564,55 @@ void RegisterAlmFitPredictAggregateFunction(ExtensionLoader &loader) {
         AlmFitPredictAggDestroy);
     func_set.AddFunction(split_opts_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+    FunctionDescription d1;
+    d1.description = "Fits an Additive Linear Model over a partition and returns per-row predictions.";
+    d1.examples = {"anofox_stats_alm_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "prediction"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits an Additive Linear Model over a partition with a MAP of options and returns per-row predictions.";
+    d2.examples = {"anofox_stats_alm_fit_predict_agg(y, x, {'distribution': 'laplace'})"};
+    d2.categories = {"regression", "prediction"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits an Additive Linear Model using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_alm_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "prediction"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits an Additive Linear Model on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_alm_fit_predict_agg(y, x, split_col, {'distribution': 'laplace'})"};
+    d4.categories = {"regression", "prediction"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("alm_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("alm_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_alm_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/anova_aggregate.cpp
+++ b/src/aggregate_functions/anova_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -202,11 +203,25 @@ void RegisterAnovaAggregateFunction(ExtensionLoader &loader) {
         nullptr, AnovaAggBind, AnovaAggDestroy);
     func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs a one-way ANOVA F-test to compare means across multiple groups.";
+    d1.examples        = {"anofox_stats_one_way_anova_agg(value, group_id)"};
+    d1.categories      = {"hypothesis-testing", "anova"};
+    d1.parameter_names = {"value", "group_id"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d1));
+    loader.RegisterFunction(std::move(info));
 
-    AggregateFunctionSet alias_set("one_way_anova_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("one_way_anova_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_one_way_anova_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/binom_test_aggregate.cpp
+++ b/src/aggregate_functions/binom_test_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -248,13 +249,34 @@ void RegisterBinomTestAggregateFunction(ExtensionLoader &loader) {
         nullptr, BinomTestAggBind, BinomTestAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs an exact binomial test comparing an observed success count to a hypothesized probability.";
+    d1.examples        = {"anofox_stats_binom_test_agg(value, {'p0': 0.5, 'alternative': 'two_sided'})"};
+    d1.categories      = {"hypothesis-testing", "proportion"};
+    d1.parameter_names = {"value", "options"};
+    d1.parameter_types = {LogicalType::BIGINT, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Performs an exact binomial test comparing an observed success count to a hypothesized probability, using default options.";
+    d2.examples        = {"anofox_stats_binom_test_agg(value)"};
+    d2.categories      = {"hypothesis-testing", "proportion"};
+    d2.parameter_names = {"value"};
+    d2.parameter_types = {LogicalType::BIGINT};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("binom_test_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("binom_test_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_binom_test_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/bls_aggregate.cpp
+++ b/src/aggregate_functions/bls_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -399,50 +400,93 @@ static unique_ptr<FunctionData> NnlsAggBind(ClientContext &context, AggregateFun
 //===--------------------------------------------------------------------===//
 void RegisterBlsAggregateFunction(ExtensionLoader &loader) {
     // BLS (Bounded Least Squares)
-    AggregateFunctionSet bls_set("anofox_stats_bls_fit_agg");
+    {
+        AggregateFunctionSet bls_set("anofox_stats_bls_fit_agg");
 
-    auto bls_basic = AggregateFunction(
-        "anofox_stats_bls_fit_agg", {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)}, LogicalType::ANY,
-        AggregateFunction::StateSize<BlsAggregateState>, BlsAggInitialize, BlsAggUpdate, BlsAggCombine, BlsAggFinalize,
-        nullptr, BlsAggBind, BlsAggDestroy);
-    bls_set.AddFunction(bls_basic);
+        auto bls_basic = AggregateFunction(
+            "anofox_stats_bls_fit_agg", {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)}, LogicalType::ANY,
+            AggregateFunction::StateSize<BlsAggregateState>, BlsAggInitialize, BlsAggUpdate, BlsAggCombine,
+            BlsAggFinalize, nullptr, BlsAggBind, BlsAggDestroy);
+        bls_set.AddFunction(bls_basic);
 
-    auto bls_map = AggregateFunction(
-        "anofox_stats_bls_fit_agg", {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY},
-        LogicalType::ANY, AggregateFunction::StateSize<BlsAggregateState>, BlsAggInitialize, BlsAggUpdate,
-        BlsAggCombine, BlsAggFinalize, nullptr, BlsAggBind, BlsAggDestroy);
-    bls_set.AddFunction(bls_map);
+        auto bls_map = AggregateFunction(
+            "anofox_stats_bls_fit_agg", {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY},
+            LogicalType::ANY, AggregateFunction::StateSize<BlsAggregateState>, BlsAggInitialize, BlsAggUpdate,
+            BlsAggCombine, BlsAggFinalize, nullptr, BlsAggBind, BlsAggDestroy);
+        bls_set.AddFunction(bls_map);
 
-    loader.RegisterFunction(bls_set);
+        CreateAggregateFunctionInfo bls_info(std::move(bls_set));
+        bls_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription d1;
+        d1.description     = "Fits a Bounded Least Squares (BLS) regression with coefficient bounds and returns fit statistics.";
+        d1.examples        = {"anofox_stats_bls_fit_agg(y, x, {'lower_bounds': [-1.0], 'upper_bounds': [1.0]})"};
+        d1.categories      = {"regression"};
+        d1.parameter_names = {"y", "x", "options"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+        bls_info.descriptions.push_back(std::move(d1));
+        FunctionDescription d2;
+        d2.description     = "Fits a Bounded Least Squares (BLS) regression with coefficient bounds and returns fit statistics.";
+        d2.examples        = {"anofox_stats_bls_fit_agg(y, x)"};
+        d2.categories      = {"regression"};
+        d2.parameter_names = {"y", "x"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+        bls_info.descriptions.push_back(std::move(d2));
+        loader.RegisterFunction(std::move(bls_info));
 
-    // Short alias
-    AggregateFunctionSet bls_alias("bls_fit_agg");
-    bls_alias.AddFunction(bls_basic);
-    bls_alias.AddFunction(bls_map);
-    loader.RegisterFunction(bls_alias);
+        // Short alias
+        AggregateFunctionSet bls_alias("bls_fit_agg");
+        bls_alias.AddFunction(bls_basic);
+        bls_alias.AddFunction(bls_map);
+        CreateAggregateFunctionInfo bls_alias_info(std::move(bls_alias));
+        bls_alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        bls_alias_info.alias_of = "anofox_stats_bls_fit_agg";
+        loader.RegisterFunction(std::move(bls_alias_info));
+    }
 
     // NNLS (Non-Negative Least Squares)
-    AggregateFunctionSet nnls_set("anofox_stats_nnls_fit_agg");
+    {
+        AggregateFunctionSet nnls_set("anofox_stats_nnls_fit_agg");
 
-    auto nnls_basic = AggregateFunction(
-        "anofox_stats_nnls_fit_agg", {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)}, LogicalType::ANY,
-        AggregateFunction::StateSize<BlsAggregateState>, BlsAggInitialize, BlsAggUpdate, BlsAggCombine, BlsAggFinalize,
-        nullptr, NnlsAggBind, BlsAggDestroy);
-    nnls_set.AddFunction(nnls_basic);
+        auto nnls_basic = AggregateFunction(
+            "anofox_stats_nnls_fit_agg", {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)}, LogicalType::ANY,
+            AggregateFunction::StateSize<BlsAggregateState>, BlsAggInitialize, BlsAggUpdate, BlsAggCombine,
+            BlsAggFinalize, nullptr, NnlsAggBind, BlsAggDestroy);
+        nnls_set.AddFunction(nnls_basic);
 
-    auto nnls_map = AggregateFunction(
-        "anofox_stats_nnls_fit_agg", {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY},
-        LogicalType::ANY, AggregateFunction::StateSize<BlsAggregateState>, BlsAggInitialize, BlsAggUpdate,
-        BlsAggCombine, BlsAggFinalize, nullptr, NnlsAggBind, BlsAggDestroy);
-    nnls_set.AddFunction(nnls_map);
+        auto nnls_map = AggregateFunction(
+            "anofox_stats_nnls_fit_agg",
+            {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY}, LogicalType::ANY,
+            AggregateFunction::StateSize<BlsAggregateState>, BlsAggInitialize, BlsAggUpdate, BlsAggCombine,
+            BlsAggFinalize, nullptr, NnlsAggBind, BlsAggDestroy);
+        nnls_set.AddFunction(nnls_map);
 
-    loader.RegisterFunction(nnls_set);
+        CreateAggregateFunctionInfo nnls_info(std::move(nnls_set));
+        nnls_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription d1;
+        d1.description     = "Fits a Non-Negative Least Squares (NNLS) regression with non-negativity constraints.";
+        d1.examples        = {"anofox_stats_nnls_fit_agg(y, x, {'tolerance': 1e-6})"};
+        d1.categories      = {"regression"};
+        d1.parameter_names = {"y", "x", "options"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+        nnls_info.descriptions.push_back(std::move(d1));
+        FunctionDescription d2;
+        d2.description     = "Fits a Non-Negative Least Squares (NNLS) regression with non-negativity constraints.";
+        d2.examples        = {"anofox_stats_nnls_fit_agg(y, x)"};
+        d2.categories      = {"regression"};
+        d2.parameter_names = {"y", "x"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+        nnls_info.descriptions.push_back(std::move(d2));
+        loader.RegisterFunction(std::move(nnls_info));
 
-    // Short alias for NNLS
-    AggregateFunctionSet nnls_alias("nnls_fit_agg");
-    nnls_alias.AddFunction(nnls_basic);
-    nnls_alias.AddFunction(nnls_map);
-    loader.RegisterFunction(nnls_alias);
+        // Short alias for NNLS
+        AggregateFunctionSet nnls_alias("nnls_fit_agg");
+        nnls_alias.AddFunction(nnls_basic);
+        nnls_alias.AddFunction(nnls_map);
+        CreateAggregateFunctionInfo nnls_alias_info(std::move(nnls_alias));
+        nnls_alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        nnls_alias_info.alias_of = "anofox_stats_nnls_fit_agg";
+        loader.RegisterFunction(std::move(nnls_alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/bls_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/bls_fit_predict_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -559,15 +560,55 @@ void RegisterBlsFitPredictAggregateFunction(ExtensionLoader &loader) {
         BlsFitPredictAggDestroy);
     func_set.AddFunction(split_opts_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+    FunctionDescription d1;
+    d1.description = "Fits a Bounded Least Squares model over a partition and returns per-row predictions.";
+    d1.examples = {"anofox_stats_bls_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "prediction"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits a Bounded Least Squares model over a partition with a MAP of options and returns per-row predictions.";
+    d2.examples = {"anofox_stats_bls_fit_predict_agg(y, x, {'null_policy': 'drop'})"};
+    d2.categories = {"regression", "prediction"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits a Bounded Least Squares model using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_bls_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "prediction"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits a Bounded Least Squares model on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_bls_fit_predict_agg(y, x, split_col, {'null_policy': 'drop'})"};
+    d4.categories = {"regression", "prediction"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("bls_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("bls_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_bls_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/brown_forsythe_aggregate.cpp
+++ b/src/aggregate_functions/brown_forsythe_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -216,12 +217,26 @@ void RegisterBrownForsytheAggregateFunction(ExtensionLoader &loader) {
         nullptr, BrownForsytheAggBind, BrownForsytheAggDestroy);
     func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Tests equality of variances across groups using the Brown-Forsythe test.";
+    d1.examples        = {"anofox_stats_brown_forsythe_agg(value, group_id)"};
+    d1.categories      = {"hypothesis-testing", "anova"};
+    d1.parameter_names = {"value", "group_id"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d1));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("brown_forsythe_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("brown_forsythe_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_brown_forsythe_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/brunner_munzel_aggregate.cpp
+++ b/src/aggregate_functions/brunner_munzel_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -260,13 +261,34 @@ void RegisterBrunnerMunzelAggregateFunction(ExtensionLoader &loader) {
         nullptr, BrunnerMunzelAggBind, BrunnerMunzelAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs the Brunner-Munzel test for stochastic equality of two independent samples.";
+    d1.examples        = {"anofox_stats_brunner_munzel_agg(value, group_id, {'alternative': 'two_sided'})"};
+    d1.categories      = {"hypothesis-testing"};
+    d1.parameter_names = {"value", "group_id", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Performs the Brunner-Munzel test for stochastic equality of two independent samples, using default options.";
+    d2.examples        = {"anofox_stats_brunner_munzel_agg(value, group_id)"};
+    d2.categories      = {"hypothesis-testing"};
+    d2.parameter_names = {"value", "group_id"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("brunner_munzel_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("brunner_munzel_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_brunner_munzel_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/chisq_aggregate.cpp
+++ b/src/aggregate_functions/chisq_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -228,12 +229,34 @@ void RegisterChiSquareAggregateFunction(ExtensionLoader &loader) {
         nullptr, ChiSquareAggBind, ChiSquareAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs a chi-squared test of independence on a 2×2 contingency table from two categorical columns.";
+    d1.examples        = {"anofox_stats_chisq_test_agg(row_var, col_var, {'correction': true})"};
+    d1.categories      = {"hypothesis-testing", "categorical"};
+    d1.parameter_names = {"row_var", "col_var", "options"};
+    d1.parameter_types = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Performs a chi-squared test of independence on a 2×2 contingency table from two categorical columns.";
+    d2.examples        = {"anofox_stats_chisq_test_agg(row_var, col_var)"};
+    d2.categories      = {"hypothesis-testing", "categorical"};
+    d2.parameter_names = {"row_var", "col_var"};
+    d2.parameter_types = {LogicalType::INTEGER, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
-    AggregateFunctionSet alias_set("chisq_test_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    // Short alias
+    {
+        AggregateFunctionSet alias_set("chisq_test_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_chisq_test_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/chisq_gof_aggregate.cpp
+++ b/src/aggregate_functions/chisq_gof_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -191,12 +192,26 @@ void RegisterChisqGofAggregateFunction(ExtensionLoader &loader) {
         nullptr, ChisqGofAggBind, ChisqGofAggDestroy);
     func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs a chi-squared goodness-of-fit test comparing observed frequencies to expected probabilities.";
+    d1.examples        = {"anofox_stats_chisq_gof_agg(observed, expected_prob)"};
+    d1.categories      = {"hypothesis-testing", "categorical"};
+    d1.parameter_names = {"observed", "expected_prob"};
+    d1.parameter_types = {LogicalType::BIGINT, LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(d1));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("chisq_gof_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("chisq_gof_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_chisq_gof_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/clark_west_aggregate.cpp
+++ b/src/aggregate_functions/clark_west_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -250,8 +251,6 @@ static unique_ptr<FunctionData> ClarkWestAggBind(ClientContext &context, Aggrega
 // Registration
 //===--------------------------------------------------------------------===//
 void RegisterClarkWestAggregateFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_clark_west_agg");
-
     // With options: (actual, forecast_restricted, forecast_unrestricted, options)
     auto func_with_opts = AggregateFunction(
         "anofox_stats_clark_west_agg",
@@ -260,7 +259,6 @@ void RegisterClarkWestAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<ClarkWestAggregateState>, ClarkWestAggInitialize,
         ClarkWestAggUpdate, ClarkWestAggCombine, ClarkWestAggFinalize,
         nullptr, ClarkWestAggBind, ClarkWestAggDestroy);
-    func_set.AddFunction(func_with_opts);
 
     // Without options: (actual, forecast_restricted, forecast_unrestricted)
     auto func_no_opts = AggregateFunction(
@@ -270,15 +268,40 @@ void RegisterClarkWestAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<ClarkWestAggregateState>, ClarkWestAggInitialize,
         ClarkWestAggUpdate, ClarkWestAggCombine, ClarkWestAggFinalize,
         nullptr, ClarkWestAggBind, ClarkWestAggDestroy);
-    func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_clark_west_agg");
+        func_set.AddFunction(func_with_opts);
+        func_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription d1;
+        d1.description     = "Performs the Clark-West test to compare a nested forecast model against an encompassing model.";
+        d1.examples        = {"anofox_stats_clark_west_agg(actual, forecast_restricted, forecast_unrestricted, {'horizon': 1})"};
+        d1.categories      = {"forecast-evaluation"};
+        d1.parameter_names = {"actual", "forecast_restricted", "forecast_unrestricted", "options"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY};
+        info.descriptions.push_back(std::move(d1));
+        FunctionDescription d2;
+        d2.description     = "Performs the Clark-West test to compare a nested forecast model against an encompassing model, using default options.";
+        d2.examples        = {"anofox_stats_clark_west_agg(actual, forecast_restricted, forecast_unrestricted)"};
+        d2.categories      = {"forecast-evaluation"};
+        d2.parameter_names = {"actual", "forecast_restricted", "forecast_unrestricted"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE};
+        info.descriptions.push_back(std::move(d2));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Short alias
-    AggregateFunctionSet alias_set("clark_west_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("clark_west_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_clark_west_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/cohen_kappa_aggregate.cpp
+++ b/src/aggregate_functions/cohen_kappa_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -268,13 +269,34 @@ void RegisterCohenKappaAggregateFunction(ExtensionLoader &loader) {
         nullptr, CohenKappaAggBind, CohenKappaAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Computes Cohen's kappa, a measure of inter-rater agreement for categorical classifications.";
+    d1.examples        = {"anofox_stats_cohen_kappa_agg(rater1, rater2, {'weighted': false})"};
+    d1.categories      = {"hypothesis-testing", "categorical"};
+    d1.parameter_names = {"rater1", "rater2", "options"};
+    d1.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Computes Cohen's kappa, a measure of inter-rater agreement for categorical classifications.";
+    d2.examples        = {"anofox_stats_cohen_kappa_agg(rater1, rater2)"};
+    d2.categories      = {"hypothesis-testing", "categorical"};
+    d2.parameter_names = {"rater1", "rater2"};
+    d2.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("cohen_kappa_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("cohen_kappa_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_cohen_kappa_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/contingency_coef_aggregate.cpp
+++ b/src/aggregate_functions/contingency_coef_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -193,12 +194,26 @@ void RegisterContingencyCoefAggregateFunction(ExtensionLoader &loader) {
         nullptr, ContingencyCoefAggBind, ContingencyCoefAggDestroy);
     func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Computes the contingency coefficient (C), a measure of association for categorical variables.";
+    d1.examples        = {"anofox_stats_contingency_coef_agg(row_var, col_var)"};
+    d1.categories      = {"hypothesis-testing", "categorical"};
+    d1.parameter_names = {"row_var", "col_var"};
+    d1.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+    info.descriptions.push_back(std::move(d1));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("contingency_coef_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("contingency_coef_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_contingency_coef_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/cramers_v_aggregate.cpp
+++ b/src/aggregate_functions/cramers_v_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -201,12 +202,26 @@ void RegisterCramersVAggregateFunction(ExtensionLoader &loader) {
         nullptr, CramersVAggBind, CramersVAggDestroy);
     func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Computes Cramér's V, a measure of association strength for nominal categorical variables.";
+    d1.examples        = {"anofox_stats_cramers_v_agg(row_var, col_var)"};
+    d1.categories      = {"hypothesis-testing", "categorical"};
+    d1.parameter_names = {"row_var", "col_var"};
+    d1.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+    info.descriptions.push_back(std::move(d1));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("cramers_v_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("cramers_v_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_cramers_v_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/dagostino_k2_aggregate.cpp
+++ b/src/aggregate_functions/dagostino_k2_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -172,21 +173,36 @@ static unique_ptr<FunctionData> DAgostinoK2AggBind(ClientContext &context, Aggre
 // Registration
 //===--------------------------------------------------------------------===//
 void RegisterDAgostinoK2AggregateFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_dagostino_k2_agg");
-
     auto func = AggregateFunction("anofox_stats_dagostino_k2_agg", {LogicalType::DOUBLE},
                                   LogicalType::ANY,
                                   AggregateFunction::StateSize<DAgostinoK2AggregateState>, DAgostinoK2AggInitialize,
                                   DAgostinoK2AggUpdate, DAgostinoK2AggCombine, DAgostinoK2AggFinalize,
                                   nullptr, DAgostinoK2AggBind, DAgostinoK2AggDestroy);
-    func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_dagostino_k2_agg");
+        func_set.AddFunction(func);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription desc;
+        desc.description     = "Performs the D'Agostino-Pearson K² omnibus normality test based on skewness and kurtosis.";
+        desc.examples        = {"anofox_stats_dagostino_k2_agg(value)"};
+        desc.categories      = {"normality-test"};
+        desc.parameter_names = {"value"};
+        desc.parameter_types = {LogicalType::DOUBLE};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Short alias
-    AggregateFunctionSet alias_set("dagostino_k2_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("dagostino_k2_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_dagostino_k2_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/diebold_mariano_aggregate.cpp
+++ b/src/aggregate_functions/diebold_mariano_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -280,8 +281,6 @@ static unique_ptr<FunctionData> DieboldMarianoAggBind(ClientContext &context, Ag
 // Registration
 //===--------------------------------------------------------------------===//
 void RegisterDieboldMarianoAggregateFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_diebold_mariano_agg");
-
     // With options: (actual, forecast1, forecast2, options)
     auto func_with_opts = AggregateFunction(
         "anofox_stats_diebold_mariano_agg",
@@ -290,7 +289,6 @@ void RegisterDieboldMarianoAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<DieboldMarianoAggregateState>, DieboldMarianoAggInitialize,
         DieboldMarianoAggUpdate, DieboldMarianoAggCombine, DieboldMarianoAggFinalize,
         nullptr, DieboldMarianoAggBind, DieboldMarianoAggDestroy);
-    func_set.AddFunction(func_with_opts);
 
     // Without options: (actual, forecast1, forecast2)
     auto func_no_opts = AggregateFunction(
@@ -300,15 +298,40 @@ void RegisterDieboldMarianoAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<DieboldMarianoAggregateState>, DieboldMarianoAggInitialize,
         DieboldMarianoAggUpdate, DieboldMarianoAggCombine, DieboldMarianoAggFinalize,
         nullptr, DieboldMarianoAggBind, DieboldMarianoAggDestroy);
-    func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_diebold_mariano_agg");
+        func_set.AddFunction(func_with_opts);
+        func_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription d1;
+        d1.description     = "Performs the Diebold-Mariano test to compare predictive accuracy of two forecast models.";
+        d1.examples        = {"anofox_stats_diebold_mariano_agg(actual, forecast1, forecast2, {'loss': 'squared'})"};
+        d1.categories      = {"forecast-evaluation"};
+        d1.parameter_names = {"actual", "forecast1", "forecast2", "options"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY};
+        info.descriptions.push_back(std::move(d1));
+        FunctionDescription d2;
+        d2.description     = "Performs the Diebold-Mariano test to compare predictive accuracy of two forecast models, using default options.";
+        d2.examples        = {"anofox_stats_diebold_mariano_agg(actual, forecast1, forecast2)"};
+        d2.categories      = {"forecast-evaluation"};
+        d2.parameter_names = {"actual", "forecast1", "forecast2"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE};
+        info.descriptions.push_back(std::move(d2));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Short alias
-    AggregateFunctionSet alias_set("diebold_mariano_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("diebold_mariano_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_diebold_mariano_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/distance_cor_aggregate.cpp
+++ b/src/aggregate_functions/distance_cor_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -244,8 +245,6 @@ static unique_ptr<FunctionData> DistanceCorAggBind(ClientContext &context, Aggre
 // Registration
 //===--------------------------------------------------------------------===//
 void RegisterDistanceCorAggregateFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_distance_cor_agg");
-
     // With options: (x, y, options)
     auto func_with_opts = AggregateFunction(
         "anofox_stats_distance_cor_agg", {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY},
@@ -253,7 +252,6 @@ void RegisterDistanceCorAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<DistanceCorAggregateState>, DistanceCorAggInitialize,
         DistanceCorAggUpdate, DistanceCorAggCombine, DistanceCorAggFinalize,
         nullptr, DistanceCorAggBind, DistanceCorAggDestroy);
-    func_set.AddFunction(func_with_opts);
 
     // Without options: (x, y)
     auto func_no_opts = AggregateFunction(
@@ -262,15 +260,40 @@ void RegisterDistanceCorAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<DistanceCorAggregateState>, DistanceCorAggInitialize,
         DistanceCorAggUpdate, DistanceCorAggCombine, DistanceCorAggFinalize,
         nullptr, DistanceCorAggBind, DistanceCorAggDestroy);
-    func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_distance_cor_agg");
+        func_set.AddFunction(func_with_opts);
+        func_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription d1;
+        d1.description     = "Computes the distance correlation between two variables, detecting both linear and nonlinear dependence.";
+        d1.examples        = {"anofox_stats_distance_cor_agg(x, y, {'n_permutations': 1000})"};
+        d1.categories      = {"correlation"};
+        d1.parameter_names = {"x", "y", "options"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY};
+        info.descriptions.push_back(std::move(d1));
+        FunctionDescription d2;
+        d2.description     = "Computes the distance correlation between two variables, detecting both linear and nonlinear dependence, using default options.";
+        d2.examples        = {"anofox_stats_distance_cor_agg(x, y)"};
+        d2.categories      = {"correlation"};
+        d2.parameter_names = {"x", "y"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE};
+        info.descriptions.push_back(std::move(d2));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Short alias
-    AggregateFunctionSet alias_set("distance_cor_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("distance_cor_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_distance_cor_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/elasticnet_aggregate.cpp
+++ b/src/aggregate_functions/elasticnet_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -379,13 +380,34 @@ void RegisterElasticNetAggregateFunction(ExtensionLoader &loader) {
                                       ElasticNetAggFinalize, nullptr, ElasticNetAggBind, ElasticNetAggDestroy);
     func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Fits an ElasticNet model combining L1 and L2 regularization and returns coefficients and fit statistics.";
+    d1.examples        = {"anofox_stats_elasticnet_fit_agg(y, x, {'alpha': 1.0, 'l1_ratio': 0.5})"};
+    d1.categories      = {"regression"};
+    d1.parameter_names = {"y", "x", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Fits an ElasticNet model combining L1 and L2 regularization and returns coefficients and fit statistics.";
+    d2.examples        = {"anofox_stats_elasticnet_fit_agg(y, x)"};
+    d2.categories      = {"regression"};
+    d2.parameter_names = {"y", "x"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Register short alias
-    AggregateFunctionSet alias_set("elasticnet_fit_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("elasticnet_fit_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_elasticnet_fit_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/elasticnet_predict_aggregate.cpp
+++ b/src/aggregate_functions/elasticnet_predict_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -505,30 +506,80 @@ void RegisterElasticNetFitPredictAggregateFunction(ExtensionLoader &loader) {
         ElasticNetPredictAggBindWithSplit, ElasticNetPredictAggDestroy);
     func_set.AddFunction(split_opts_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+    FunctionDescription d1;
+    d1.description = "Fits ElasticNet regression over a partition and returns per-row predictions with confidence intervals.";
+    d1.examples = {"anofox_stats_elasticnet_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "prediction"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits ElasticNet regression over a partition with a MAP of options and returns per-row predictions with confidence intervals.";
+    d2.examples = {"anofox_stats_elasticnet_fit_predict_agg(y, x, {'null_policy': 'drop'})"};
+    d2.categories = {"regression", "prediction"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits ElasticNet regression using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_elasticnet_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "prediction"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits ElasticNet regression on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_elasticnet_fit_predict_agg(y, x, split_col, {'null_policy': 'drop'})"};
+    d4.categories = {"regression", "prediction"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
 
     // Short alias (new)
-    AggregateFunctionSet alias_set("elasticnet_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("elasticnet_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_elasticnet_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 
     // Deprecated aliases (old names for backwards compatibility)
-    AggregateFunctionSet deprecated_set("elasticnet_predict_agg");
-    deprecated_set.AddFunction(basic_func);
-    deprecated_set.AddFunction(map_func);
-    deprecated_set.AddFunction(split_func);
-    deprecated_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(deprecated_set);
+    {
+        AggregateFunctionSet dep_set("elasticnet_predict_agg");
+        dep_set.AddFunction(basic_func);
+        dep_set.AddFunction(map_func);
+        dep_set.AddFunction(split_func);
+        dep_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo dep_info(std::move(dep_set));
+        dep_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        dep_info.alias_of = "anofox_stats_elasticnet_fit_predict_agg";
+        loader.RegisterFunction(std::move(dep_info));
+    }
 
-    AggregateFunctionSet deprecated_full_set("anofox_stats_elasticnet_predict_agg");
-    deprecated_full_set.AddFunction(basic_func);
-    deprecated_full_set.AddFunction(map_func);
-    deprecated_full_set.AddFunction(split_func);
-    deprecated_full_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(deprecated_full_set);
+    {
+        AggregateFunctionSet dep2_set("anofox_stats_elasticnet_predict_agg");
+        dep2_set.AddFunction(basic_func);
+        dep2_set.AddFunction(map_func);
+        dep2_set.AddFunction(split_func);
+        dep2_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo dep2_info(std::move(dep2_set));
+        dep2_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        dep2_info.alias_of = "anofox_stats_elasticnet_fit_predict_agg";
+        loader.RegisterFunction(std::move(dep2_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/energy_distance_aggregate.cpp
+++ b/src/aggregate_functions/energy_distance_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -228,8 +229,6 @@ static unique_ptr<FunctionData> EnergyDistanceAggBind(ClientContext &context, Ag
 // Registration
 //===--------------------------------------------------------------------===//
 void RegisterEnergyDistanceAggregateFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_energy_distance_agg");
-
     // With options
     auto func_with_opts = AggregateFunction(
         "anofox_stats_energy_distance_agg", {LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::ANY},
@@ -237,7 +236,6 @@ void RegisterEnergyDistanceAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<EnergyDistanceAggregateState>, EnergyDistanceAggInitialize,
         EnergyDistanceAggUpdate, EnergyDistanceAggCombine, EnergyDistanceAggFinalize,
         nullptr, EnergyDistanceAggBind, EnergyDistanceAggDestroy);
-    func_set.AddFunction(func_with_opts);
 
     // Without options
     auto func_no_opts = AggregateFunction(
@@ -246,15 +244,40 @@ void RegisterEnergyDistanceAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<EnergyDistanceAggregateState>, EnergyDistanceAggInitialize,
         EnergyDistanceAggUpdate, EnergyDistanceAggCombine, EnergyDistanceAggFinalize,
         nullptr, EnergyDistanceAggBind, EnergyDistanceAggDestroy);
-    func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_energy_distance_agg");
+        func_set.AddFunction(func_with_opts);
+        func_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription d1;
+        d1.description     = "Computes the energy distance between two samples as a measure of distributional difference.";
+        d1.examples        = {"anofox_stats_energy_distance_agg(value, group_id, {'n_permutations': 1000})"};
+        d1.categories      = {"distribution-comparison"};
+        d1.parameter_names = {"value", "group_id", "options"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::ANY};
+        info.descriptions.push_back(std::move(d1));
+        FunctionDescription d2;
+        d2.description     = "Computes the energy distance between two samples as a measure of distributional difference, using default options.";
+        d2.examples        = {"anofox_stats_energy_distance_agg(value, group_id)"};
+        d2.categories      = {"distribution-comparison"};
+        d2.parameter_names = {"value", "group_id"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+        info.descriptions.push_back(std::move(d2));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Short alias
-    AggregateFunctionSet alias_set("energy_distance_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("energy_distance_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_energy_distance_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/fisher_exact_aggregate.cpp
+++ b/src/aggregate_functions/fisher_exact_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -250,13 +251,34 @@ void RegisterFisherExactAggregateFunction(ExtensionLoader &loader) {
         nullptr, FisherExactAggBind, FisherExactAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs Fisher's exact test for association in a 2×2 contingency table.";
+    d1.examples        = {"anofox_stats_fisher_exact_agg(row_var, col_var, {'alternative': 'two_sided'})"};
+    d1.categories      = {"hypothesis-testing", "categorical"};
+    d1.parameter_names = {"row_var", "col_var", "options"};
+    d1.parameter_types = {LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Performs Fisher's exact test for association in a 2×2 contingency table.";
+    d2.examples        = {"anofox_stats_fisher_exact_agg(row_var, col_var)"};
+    d2.categories      = {"hypothesis-testing", "categorical"};
+    d2.parameter_names = {"row_var", "col_var"};
+    d2.parameter_types = {LogicalType::INTEGER, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("fisher_exact_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("fisher_exact_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_fisher_exact_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/g_test_aggregate.cpp
+++ b/src/aggregate_functions/g_test_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -217,12 +218,26 @@ void RegisterGTestAggregateFunction(ExtensionLoader &loader) {
         nullptr, GTestAggBind, GTestAggDestroy);
     func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs a G-test (log-likelihood ratio test) for goodness of fit or independence.";
+    d1.examples        = {"anofox_stats_g_test_agg(row_var, col_var)"};
+    d1.categories      = {"hypothesis-testing", "categorical"};
+    d1.parameter_names = {"row_var", "col_var"};
+    d1.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+    info.descriptions.push_back(std::move(d1));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("g_test_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("g_test_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_g_test_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/icc_aggregate.cpp
+++ b/src/aggregate_functions/icc_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -306,13 +307,34 @@ void RegisterIccAggregateFunction(ExtensionLoader &loader) {
         nullptr, IccAggBind, IccAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Computes the Intraclass Correlation Coefficient (ICC) to measure rater or measurement consistency.";
+    d1.examples        = {"anofox_stats_icc_agg(value, subject_id, rater_id, {'type': 'single'})"};
+    d1.categories      = {"correlation"};
+    d1.parameter_names = {"value", "subject_id", "rater_id", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Computes the Intraclass Correlation Coefficient (ICC) to measure rater or measurement consistency.";
+    d2.examples        = {"anofox_stats_icc_agg(value, subject_id, rater_id)"};
+    d2.categories      = {"correlation"};
+    d2.parameter_names = {"value", "subject_id", "rater_id"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::BIGINT};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("icc_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("icc_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_icc_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/isotonic_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/isotonic_fit_predict_aggregate.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -426,14 +427,54 @@ void RegisterIsotonicFitPredictAggregateFunction(ExtensionLoader &loader) {
         IsotonicPredictAggCombine, IsotonicPredictAggFinalize, nullptr, IsotonicPredictAggBindWithSplit, IsotonicPredictAggDestroy);
     func_set.AddFunction(split_map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    AggregateFunctionSet alias_set("isotonic_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_map_func);
-    loader.RegisterFunction(alias_set);
+    FunctionDescription d1;
+    d1.description = "Fits an isotonic regression model over a partition and returns per-row predictions.";
+    d1.examples = {"anofox_stats_isotonic_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "nonparametric"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits an isotonic regression model over a partition with a MAP of options and returns per-row predictions.";
+    d2.examples = {"anofox_stats_isotonic_fit_predict_agg(y, x, {'increasing': true})"};
+    d2.categories = {"regression", "nonparametric"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits an isotonic regression model using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_isotonic_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "nonparametric"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits an isotonic regression model on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_isotonic_fit_predict_agg(y, x, split_col, {'increasing': true})"};
+    d4.categories = {"regression", "nonparametric"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
+
+    {
+        AggregateFunctionSet alias_set("isotonic_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_isotonic_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/jarque_bera_aggregate.cpp
+++ b/src/aggregate_functions/jarque_bera_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -170,22 +171,37 @@ static unique_ptr<FunctionData> JarqueBeraAggBind(ClientContext &context, Aggreg
 // Registration
 //===--------------------------------------------------------------------===//
 void RegisterJarqueBeraAggregateFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_jarque_bera_agg");
-
     auto func = AggregateFunction("anofox_stats_jarque_bera_agg", {LogicalType::DOUBLE},
                                   LogicalType::ANY, // Set in bind
                                   AggregateFunction::StateSize<JarqueBeraAggregateState>, JarqueBeraAggInitialize,
                                   JarqueBeraAggUpdate, JarqueBeraAggCombine, JarqueBeraAggFinalize,
                                   nullptr, // simple_update
                                   JarqueBeraAggBind, JarqueBeraAggDestroy);
-    func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_jarque_bera_agg");
+        func_set.AddFunction(func);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription desc;
+        desc.description     = "Aggregate version of the Jarque-Bera normality test, applied to a column of values.";
+        desc.examples        = {"anofox_stats_jarque_bera_agg(value)"};
+        desc.categories      = {"normality-test"};
+        desc.parameter_names = {"value"};
+        desc.parameter_types = {LogicalType::DOUBLE};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Also register short alias
-    AggregateFunctionSet alias_set("jarque_bera_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("jarque_bera_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_jarque_bera_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/kendall_aggregate.cpp
+++ b/src/aggregate_functions/kendall_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -260,13 +261,34 @@ void RegisterKendallAggregateFunction(ExtensionLoader &loader) {
         nullptr, KendallAggBind, KendallAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Computes Kendall's tau rank correlation coefficient and tests its significance.";
+    d1.examples        = {"anofox_stats_kendall_agg(x, y, {'alternative': 'two_sided'})"};
+    d1.categories      = {"correlation"};
+    d1.parameter_names = {"x", "y", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Computes Kendall's tau rank correlation coefficient and tests its significance.";
+    d2.examples        = {"anofox_stats_kendall_agg(x, y)"};
+    d2.categories      = {"correlation"};
+    d2.parameter_names = {"x", "y"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("kendall_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("kendall_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_kendall_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/kruskal_wallis_aggregate.cpp
+++ b/src/aggregate_functions/kruskal_wallis_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -193,11 +194,25 @@ void RegisterKruskalWallisAggregateFunction(ExtensionLoader &loader) {
         nullptr, KruskalWallisAggBind, KruskalWallisAggDestroy);
     func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs the Kruskal-Wallis H-test, a nonparametric alternative to one-way ANOVA.";
+    d1.examples        = {"anofox_stats_kruskal_wallis_agg(value, group_id)"};
+    d1.categories      = {"hypothesis-testing", "nonparametric"};
+    d1.parameter_names = {"value", "group_id"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d1));
+    loader.RegisterFunction(std::move(info));
 
-    AggregateFunctionSet alias_set("kruskal_wallis_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("kruskal_wallis_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_kruskal_wallis_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/mann_whitney_aggregate.cpp
+++ b/src/aggregate_functions/mann_whitney_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -251,12 +252,33 @@ void RegisterMannWhitneyAggregateFunction(ExtensionLoader &loader) {
         nullptr, MannWhitneyAggBind, MannWhitneyAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs the Mann-Whitney U test (Wilcoxon rank-sum) for two independent samples.";
+    d1.examples        = {"anofox_stats_mann_whitney_u_agg(value, group_id, {'alternative': 'two_sided'})"};
+    d1.categories      = {"hypothesis-testing", "nonparametric"};
+    d1.parameter_names = {"value", "group_id", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Performs the Mann-Whitney U test (Wilcoxon rank-sum) for two independent samples, using default options.";
+    d2.examples        = {"anofox_stats_mann_whitney_u_agg(value, group_id)"};
+    d2.categories      = {"hypothesis-testing", "nonparametric"};
+    d2.parameter_names = {"value", "group_id"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
-    AggregateFunctionSet alias_set("mann_whitney_u_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("mann_whitney_u_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_mann_whitney_u_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/mcnemar_aggregate.cpp
+++ b/src/aggregate_functions/mcnemar_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -249,13 +250,34 @@ void RegisterMcNemarAggregateFunction(ExtensionLoader &loader) {
         nullptr, McNemarAggBind, McNemarAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs McNemar's test for marginal homogeneity in paired categorical data.";
+    d1.examples        = {"anofox_stats_mcnemar_agg(var1, var2, {'correction': true})"};
+    d1.categories      = {"hypothesis-testing", "categorical"};
+    d1.parameter_names = {"var1", "var2", "options"};
+    d1.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Performs McNemar's test for marginal homogeneity in paired categorical data.";
+    d2.examples        = {"anofox_stats_mcnemar_agg(var1, var2)"};
+    d2.categories      = {"hypothesis-testing", "categorical"};
+    d2.parameter_names = {"var1", "var2"};
+    d2.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("mcnemar_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("mcnemar_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_mcnemar_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/mmd_aggregate.cpp
+++ b/src/aggregate_functions/mmd_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -229,8 +230,6 @@ static unique_ptr<FunctionData> MmdAggBind(ClientContext &context, AggregateFunc
 // Registration
 //===--------------------------------------------------------------------===//
 void RegisterMmdAggregateFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_mmd_agg");
-
     // With options
     auto func_with_opts = AggregateFunction(
         "anofox_stats_mmd_agg", {LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::ANY},
@@ -238,7 +237,6 @@ void RegisterMmdAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<MmdAggregateState>, MmdAggInitialize,
         MmdAggUpdate, MmdAggCombine, MmdAggFinalize,
         nullptr, MmdAggBind, MmdAggDestroy);
-    func_set.AddFunction(func_with_opts);
 
     // Without options
     auto func_no_opts = AggregateFunction(
@@ -247,15 +245,40 @@ void RegisterMmdAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<MmdAggregateState>, MmdAggInitialize,
         MmdAggUpdate, MmdAggCombine, MmdAggFinalize,
         nullptr, MmdAggBind, MmdAggDestroy);
-    func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_mmd_agg");
+        func_set.AddFunction(func_with_opts);
+        func_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription d1;
+        d1.description     = "Computes the Maximum Mean Discrepancy (MMD) between two samples to test distributional similarity.";
+        d1.examples        = {"anofox_stats_mmd_agg(value, group_id, {'n_permutations': 1000})"};
+        d1.categories      = {"distribution-comparison"};
+        d1.parameter_names = {"value", "group_id", "options"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::ANY};
+        info.descriptions.push_back(std::move(d1));
+        FunctionDescription d2;
+        d2.description     = "Computes the Maximum Mean Discrepancy (MMD) between two samples to test distributional similarity, using default options.";
+        d2.examples        = {"anofox_stats_mmd_agg(value, group_id)"};
+        d2.categories      = {"distribution-comparison"};
+        d2.parameter_names = {"value", "group_id"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+        info.descriptions.push_back(std::move(d2));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Short alias
-    AggregateFunctionSet alias_set("mmd_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("mmd_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_mmd_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/ols_aggregate.cpp
+++ b/src/aggregate_functions/ols_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -394,13 +395,34 @@ void RegisterOlsAggregateFunction(ExtensionLoader &loader) {
                                       OlsAggBind, OlsAggDestroy);
     func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Fits an OLS regression model and returns coefficients and fit statistics as a struct.";
+    d1.examples        = {"anofox_stats_ols_fit_agg(y, x, {'fit_intercept': true})"};
+    d1.categories      = {"regression"};
+    d1.parameter_names = {"y", "x", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Fits an OLS regression model and returns coefficients and fit statistics as a struct.";
+    d2.examples        = {"anofox_stats_ols_fit_agg(y, x)"};
+    d2.categories      = {"regression"};
+    d2.parameter_names = {"y", "x"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Register short alias
-    AggregateFunctionSet alias_set("ols_fit_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("ols_fit_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_ols_fit_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/ols_predict_aggregate.cpp
+++ b/src/aggregate_functions/ols_predict_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -511,30 +512,80 @@ void RegisterOlsFitPredictAggregateFunction(ExtensionLoader &loader) {
         OlsPredictAggDestroy);
     func_set.AddFunction(split_opts_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+    FunctionDescription d1;
+    d1.description = "Fits OLS regression over a partition and returns per-row predictions with confidence intervals.";
+    d1.examples = {"anofox_stats_ols_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "prediction"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits OLS regression over a partition with a MAP of options and returns per-row predictions with confidence intervals.";
+    d2.examples = {"anofox_stats_ols_fit_predict_agg(y, x, {'null_policy': 'drop'})"};
+    d2.categories = {"regression", "prediction"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits OLS regression using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_ols_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "prediction"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits OLS regression on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_ols_fit_predict_agg(y, x, split_col, {'null_policy': 'drop'})"};
+    d4.categories = {"regression", "prediction"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
 
     // Short alias (new)
-    AggregateFunctionSet alias_set("ols_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("ols_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_ols_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 
     // Deprecated aliases (old names for backwards compatibility)
-    AggregateFunctionSet deprecated_set("ols_predict_agg");
-    deprecated_set.AddFunction(basic_func);
-    deprecated_set.AddFunction(map_func);
-    deprecated_set.AddFunction(split_func);
-    deprecated_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(deprecated_set);
+    {
+        AggregateFunctionSet dep_set("ols_predict_agg");
+        dep_set.AddFunction(basic_func);
+        dep_set.AddFunction(map_func);
+        dep_set.AddFunction(split_func);
+        dep_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo dep_info(std::move(dep_set));
+        dep_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        dep_info.alias_of = "anofox_stats_ols_fit_predict_agg";
+        loader.RegisterFunction(std::move(dep_info));
+    }
 
-    AggregateFunctionSet deprecated_full_set("anofox_stats_ols_predict_agg");
-    deprecated_full_set.AddFunction(basic_func);
-    deprecated_full_set.AddFunction(map_func);
-    deprecated_full_set.AddFunction(split_func);
-    deprecated_full_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(deprecated_full_set);
+    {
+        AggregateFunctionSet dep2_set("anofox_stats_ols_predict_agg");
+        dep2_set.AddFunction(basic_func);
+        dep2_set.AddFunction(map_func);
+        dep2_set.AddFunction(split_func);
+        dep2_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo dep2_info(std::move(dep2_set));
+        dep2_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        dep2_info.alias_of = "anofox_stats_ols_fit_predict_agg";
+        loader.RegisterFunction(std::move(dep2_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/pearson_aggregate.cpp
+++ b/src/aggregate_functions/pearson_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -248,13 +249,34 @@ void RegisterPearsonAggregateFunction(ExtensionLoader &loader) {
         nullptr, PearsonAggBind, PearsonAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Computes Pearson's product-moment correlation coefficient and tests its significance.";
+    d1.examples        = {"anofox_stats_pearson_agg(x, y, {'alternative': 'two_sided'})"};
+    d1.categories      = {"correlation"};
+    d1.parameter_names = {"x", "y", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Computes Pearson's product-moment correlation coefficient and tests its significance.";
+    d2.examples        = {"anofox_stats_pearson_agg(x, y)"};
+    d2.categories      = {"correlation"};
+    d2.parameter_names = {"x", "y"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("pearson_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("pearson_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_pearson_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/permutation_t_test_aggregate.cpp
+++ b/src/aggregate_functions/permutation_t_test_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -268,13 +269,34 @@ void RegisterPermutationTTestAggregateFunction(ExtensionLoader &loader) {
         nullptr, PermutationTTestAggBind, PermutationTTestAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs a permutation-based two-sample t-test using resampling.";
+    d1.examples        = {"anofox_stats_permutation_t_test_agg(value, group_id, {'alternative': 'two_sided', 'n_permutations': 10000})"};
+    d1.categories      = {"hypothesis-testing", "nonparametric"};
+    d1.parameter_names = {"value", "group_id", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Performs a permutation-based two-sample t-test using resampling, using default options.";
+    d2.examples        = {"anofox_stats_permutation_t_test_agg(value, group_id)"};
+    d2.categories      = {"hypothesis-testing", "nonparametric"};
+    d2.parameter_names = {"value", "group_id"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("permutation_t_test_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("permutation_t_test_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_permutation_t_test_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/phi_coefficient_aggregate.cpp
+++ b/src/aggregate_functions/phi_coefficient_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -195,12 +196,26 @@ void RegisterPhiCoefficientAggregateFunction(ExtensionLoader &loader) {
         nullptr, PhiCoefficientAggBind, PhiCoefficientAggDestroy);
     func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Computes the phi coefficient (φ), a measure of association for 2×2 contingency tables.";
+    d1.examples        = {"anofox_stats_phi_coefficient_agg(row_var, col_var)"};
+    d1.categories      = {"hypothesis-testing", "categorical"};
+    d1.parameter_names = {"row_var", "col_var"};
+    d1.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+    info.descriptions.push_back(std::move(d1));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("phi_coefficient_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("phi_coefficient_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_phi_coefficient_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/pls_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/pls_fit_predict_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -415,14 +416,54 @@ void RegisterPlsFitPredictAggregateFunction(ExtensionLoader &loader) {
         PlsPredictAggCombine, PlsPredictAggFinalize, nullptr, PlsPredictAggBindWithSplit, PlsPredictAggDestroy);
     func_set.AddFunction(split_map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    AggregateFunctionSet alias_set("pls_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_map_func);
-    loader.RegisterFunction(alias_set);
+    FunctionDescription d1;
+    d1.description = "Fits a Partial Least Squares model over a partition and returns per-row predictions.";
+    d1.examples = {"anofox_stats_pls_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "partial-least-squares"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits a Partial Least Squares model over a partition with a MAP of options and returns per-row predictions.";
+    d2.examples = {"anofox_stats_pls_fit_predict_agg(y, x, {'n_components': 2})"};
+    d2.categories = {"regression", "partial-least-squares"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits a Partial Least Squares model using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_pls_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "partial-least-squares"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits a Partial Least Squares model on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_pls_fit_predict_agg(y, x, split_col, {'n_components': 2})"};
+    d4.categories = {"regression", "partial-least-squares"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
+
+    {
+        AggregateFunctionSet alias_set("pls_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_pls_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/poisson_aggregate.cpp
+++ b/src/aggregate_functions/poisson_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -399,12 +400,33 @@ void RegisterPoissonAggregateFunction(ExtensionLoader &loader) {
         PoissonAggFinalize, nullptr, PoissonAggBind, PoissonAggDestroy);
     func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Fits a Poisson regression (GLM with log link) and returns coefficients, deviance, AIC, and fit statistics.";
+    d1.examples        = {"anofox_stats_poisson_fit_agg(y, x, {'fit_intercept': true})"};
+    d1.categories      = {"regression"};
+    d1.parameter_names = {"y", "x", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Fits a Poisson regression (GLM with log link) and returns coefficients, deviance, AIC, and fit statistics.";
+    d2.examples        = {"anofox_stats_poisson_fit_agg(y, x)"};
+    d2.categories      = {"regression"};
+    d2.parameter_names = {"y", "x"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
-    AggregateFunctionSet alias_set("poisson_fit_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("poisson_fit_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_poisson_fit_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/poisson_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/poisson_fit_predict_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -607,15 +608,55 @@ void RegisterPoissonFitPredictAggregateFunction(ExtensionLoader &loader) {
         PoissonFitPredictAggCombine, PoissonFitPredictAggFinalize, nullptr, PoissonFitPredictAggBindWithSplit, PoissonFitPredictAggDestroy);
     func_set.AddFunction(split_map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+    FunctionDescription d1;
+    d1.description = "Fits a Poisson regression over a partition and returns per-row predictions.";
+    d1.examples = {"anofox_stats_poisson_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "prediction"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits a Poisson regression over a partition with a MAP of options and returns per-row predictions.";
+    d2.examples = {"anofox_stats_poisson_fit_predict_agg(y, x, {'link': 'log'})"};
+    d2.categories = {"regression", "prediction"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits a Poisson regression using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_poisson_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "prediction"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits a Poisson regression on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_poisson_fit_predict_agg(y, x, split_col, {'link': 'log'})"};
+    d4.categories = {"regression", "prediction"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("poisson_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_map_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("poisson_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_poisson_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/prop_test_one_aggregate.cpp
+++ b/src/aggregate_functions/prop_test_one_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -248,13 +249,34 @@ void RegisterPropTestOneAggregateFunction(ExtensionLoader &loader) {
         nullptr, PropTestOneAggBind, PropTestOneAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Tests whether an observed proportion differs from a hypothesized value (one-sample proportion test).";
+    d1.examples        = {"anofox_stats_prop_test_one_agg(value, {'p0': 0.5, 'alternative': 'two_sided'})"};
+    d1.categories      = {"hypothesis-testing", "proportion"};
+    d1.parameter_names = {"value", "options"};
+    d1.parameter_types = {LogicalType::BIGINT, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Tests whether an observed proportion differs from a hypothesized value (one-sample proportion test), using default options.";
+    d2.examples        = {"anofox_stats_prop_test_one_agg(value)"};
+    d2.categories      = {"hypothesis-testing", "proportion"};
+    d2.parameter_names = {"value"};
+    d2.parameter_types = {LogicalType::BIGINT};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("prop_test_one_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("prop_test_one_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_prop_test_one_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/prop_test_two_aggregate.cpp
+++ b/src/aggregate_functions/prop_test_two_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -267,13 +268,34 @@ void RegisterPropTestTwoAggregateFunction(ExtensionLoader &loader) {
         nullptr, PropTestTwoAggBind, PropTestTwoAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Tests whether two observed proportions are equal (two-sample proportion test).";
+    d1.examples        = {"anofox_stats_prop_test_two_agg(value, group_id, {'alternative': 'two_sided'})"};
+    d1.categories      = {"hypothesis-testing", "proportion"};
+    d1.parameter_names = {"value", "group_id", "options"};
+    d1.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Tests whether two observed proportions are equal (two-sample proportion test), using default options.";
+    d2.examples        = {"anofox_stats_prop_test_two_agg(value, group_id)"};
+    d2.categories      = {"hypothesis-testing", "proportion"};
+    d2.parameter_names = {"value", "group_id"};
+    d2.parameter_types = {LogicalType::BIGINT, LogicalType::BIGINT};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("prop_test_two_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("prop_test_two_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_prop_test_two_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/quantile_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/quantile_fit_predict_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -417,14 +418,54 @@ void RegisterQuantileFitPredictAggregateFunction(ExtensionLoader &loader) {
         QuantilePredictAggCombine, QuantilePredictAggFinalize, nullptr, QuantilePredictAggBindWithSplit, QuantilePredictAggDestroy);
     func_set.AddFunction(split_map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    AggregateFunctionSet alias_set("quantile_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_map_func);
-    loader.RegisterFunction(alias_set);
+    FunctionDescription d1;
+    d1.description = "Fits a quantile regression model over a partition and returns per-row predictions.";
+    d1.examples = {"anofox_stats_quantile_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "quantile"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits a quantile regression model over a partition with a MAP of options and returns per-row predictions.";
+    d2.examples = {"anofox_stats_quantile_fit_predict_agg(y, x, {'quantile': 0.5})"};
+    d2.categories = {"regression", "quantile"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits a quantile regression model using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_quantile_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "quantile"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits a quantile regression model on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_quantile_fit_predict_agg(y, x, split_col, {'quantile': 0.5})"};
+    d4.categories = {"regression", "quantile"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
+
+    {
+        AggregateFunctionSet alias_set("quantile_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_quantile_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/residuals_diagnostics_aggregate.cpp
+++ b/src/aggregate_functions/residuals_diagnostics_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -337,13 +338,37 @@ void RegisterResidualsDiagnosticsAggregateFunction(ExtensionLoader &loader) {
         ResidualsDiagnosticsAggBind, ResidualsDiagnosticsAggDestroy);
     func_set.AddFunction(full_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+    FunctionDescription d1;
+    d1.description = "Aggregate version of residuals diagnostics: computes raw, standardized, studentized residuals and leverage from predicted and actual values.";
+    d1.examples = {"anofox_stats_residuals_diagnostics_agg(y, y_hat)"};
+    d1.categories = {"regression-diagnostics"};
+    d1.parameter_names = {"y", "y_hat"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Aggregate version of residuals diagnostics with feature matrix: computes raw, standardized, studentized residuals and leverage from predicted and actual values.";
+    d2.examples = {"anofox_stats_residuals_diagnostics_agg(y, y_hat, x)"};
+    d2.categories = {"regression-diagnostics"};
+    d2.parameter_names = {"y", "y_hat", "x"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d2));
+
+    loader.RegisterFunction(std::move(info));
 
     // Also register short aliases
-    AggregateFunctionSet alias_set("residuals_diagnostics_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(full_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("residuals_diagnostics_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(full_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_residuals_diagnostics_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/ridge_aggregate.cpp
+++ b/src/aggregate_functions/ridge_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -406,13 +407,34 @@ void RegisterRidgeAggregateFunction(ExtensionLoader &loader) {
                                       RidgeAggBind, RidgeAggDestroy);
     func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Fits a Ridge regression model with L2 regularization and returns coefficients and fit statistics.";
+    d1.examples        = {"anofox_stats_ridge_fit_agg(y, x, {'alpha': 1.0})"};
+    d1.categories      = {"regression"};
+    d1.parameter_names = {"y", "x", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Fits a Ridge regression model with L2 regularization and returns coefficients and fit statistics.";
+    d2.examples        = {"anofox_stats_ridge_fit_agg(y, x)"};
+    d2.categories      = {"regression"};
+    d2.parameter_names = {"y", "x"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Register short alias
-    AggregateFunctionSet alias_set("ridge_fit_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("ridge_fit_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_ridge_fit_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/ridge_predict_aggregate.cpp
+++ b/src/aggregate_functions/ridge_predict_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -490,30 +491,80 @@ void RegisterRidgeFitPredictAggregateFunction(ExtensionLoader &loader) {
         RidgePredictAggDestroy);
     func_set.AddFunction(split_opts_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+    FunctionDescription d1;
+    d1.description = "Fits Ridge regression over a partition and returns per-row predictions with confidence intervals.";
+    d1.examples = {"anofox_stats_ridge_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "prediction"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits Ridge regression over a partition with a MAP of options and returns per-row predictions with confidence intervals.";
+    d2.examples = {"anofox_stats_ridge_fit_predict_agg(y, x, {'null_policy': 'drop'})"};
+    d2.categories = {"regression", "prediction"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits Ridge regression using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_ridge_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "prediction"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits Ridge regression on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_ridge_fit_predict_agg(y, x, split_col, {'null_policy': 'drop'})"};
+    d4.categories = {"regression", "prediction"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
 
     // Short alias (new)
-    AggregateFunctionSet alias_set("ridge_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("ridge_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_ridge_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 
     // Deprecated aliases (old names for backwards compatibility)
-    AggregateFunctionSet deprecated_set("ridge_predict_agg");
-    deprecated_set.AddFunction(basic_func);
-    deprecated_set.AddFunction(map_func);
-    deprecated_set.AddFunction(split_func);
-    deprecated_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(deprecated_set);
+    {
+        AggregateFunctionSet dep_set("ridge_predict_agg");
+        dep_set.AddFunction(basic_func);
+        dep_set.AddFunction(map_func);
+        dep_set.AddFunction(split_func);
+        dep_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo dep_info(std::move(dep_set));
+        dep_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        dep_info.alias_of = "anofox_stats_ridge_fit_predict_agg";
+        loader.RegisterFunction(std::move(dep_info));
+    }
 
-    AggregateFunctionSet deprecated_full_set("anofox_stats_ridge_predict_agg");
-    deprecated_full_set.AddFunction(basic_func);
-    deprecated_full_set.AddFunction(map_func);
-    deprecated_full_set.AddFunction(split_func);
-    deprecated_full_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(deprecated_full_set);
+    {
+        AggregateFunctionSet dep2_set("anofox_stats_ridge_predict_agg");
+        dep2_set.AddFunction(basic_func);
+        dep2_set.AddFunction(map_func);
+        dep2_set.AddFunction(split_func);
+        dep2_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo dep2_info(std::move(dep2_set));
+        dep2_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        dep2_info.alias_of = "anofox_stats_ridge_fit_predict_agg";
+        loader.RegisterFunction(std::move(dep2_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/rls_aggregate.cpp
+++ b/src/aggregate_functions/rls_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -347,13 +348,34 @@ void RegisterRlsAggregateFunction(ExtensionLoader &loader) {
                                       RlsAggBind, RlsAggDestroy);
     func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Fits a Recursive Least Squares model and returns coefficients and fit statistics.";
+    d1.examples        = {"anofox_stats_rls_fit_agg(y, x, {'forgetting_factor': 0.99})"};
+    d1.categories      = {"regression"};
+    d1.parameter_names = {"y", "x", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Fits a Recursive Least Squares model and returns coefficients and fit statistics.";
+    d2.examples        = {"anofox_stats_rls_fit_agg(y, x)"};
+    d2.categories      = {"regression"};
+    d2.parameter_names = {"y", "x"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Register short alias
-    AggregateFunctionSet alias_set("rls_fit_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("rls_fit_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_rls_fit_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/rls_predict_aggregate.cpp
+++ b/src/aggregate_functions/rls_predict_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -464,30 +465,80 @@ void RegisterRlsFitPredictAggregateFunction(ExtensionLoader &loader) {
         RlsPredictAggDestroy);
     func_set.AddFunction(split_opts_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+    FunctionDescription d1;
+    d1.description = "Fits Robust LS regression over a partition and returns per-row predictions.";
+    d1.examples = {"anofox_stats_rls_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "prediction"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits Robust LS regression over a partition with a MAP of options and returns per-row predictions.";
+    d2.examples = {"anofox_stats_rls_fit_predict_agg(y, x, {'null_policy': 'drop'})"};
+    d2.categories = {"regression", "prediction"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits Robust LS regression using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_rls_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "prediction"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits Robust LS regression on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_rls_fit_predict_agg(y, x, split_col, {'null_policy': 'drop'})"};
+    d4.categories = {"regression", "prediction"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
 
     // Short alias (new)
-    AggregateFunctionSet alias_set("rls_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("rls_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_rls_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 
     // Deprecated aliases (old names for backwards compatibility)
-    AggregateFunctionSet deprecated_set("rls_predict_agg");
-    deprecated_set.AddFunction(basic_func);
-    deprecated_set.AddFunction(map_func);
-    deprecated_set.AddFunction(split_func);
-    deprecated_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(deprecated_set);
+    {
+        AggregateFunctionSet dep_set("rls_predict_agg");
+        dep_set.AddFunction(basic_func);
+        dep_set.AddFunction(map_func);
+        dep_set.AddFunction(split_func);
+        dep_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo dep_info(std::move(dep_set));
+        dep_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        dep_info.alias_of = "anofox_stats_rls_fit_predict_agg";
+        loader.RegisterFunction(std::move(dep_info));
+    }
 
-    AggregateFunctionSet deprecated_full_set("anofox_stats_rls_predict_agg");
-    deprecated_full_set.AddFunction(basic_func);
-    deprecated_full_set.AddFunction(map_func);
-    deprecated_full_set.AddFunction(split_func);
-    deprecated_full_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(deprecated_full_set);
+    {
+        AggregateFunctionSet dep2_set("anofox_stats_rls_predict_agg");
+        dep2_set.AddFunction(basic_func);
+        dep2_set.AddFunction(map_func);
+        dep2_set.AddFunction(split_func);
+        dep2_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo dep2_info(std::move(dep2_set));
+        dep2_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        dep2_info.alias_of = "anofox_stats_rls_fit_predict_agg";
+        loader.RegisterFunction(std::move(dep2_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/shapiro_wilk_aggregate.cpp
+++ b/src/aggregate_functions/shapiro_wilk_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -173,22 +174,37 @@ static unique_ptr<FunctionData> ShapiroWilkAggBind(ClientContext &context, Aggre
 // Registration
 //===--------------------------------------------------------------------===//
 void RegisterShapiroWilkAggregateFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_shapiro_wilk_agg");
-
     auto func = AggregateFunction("anofox_stats_shapiro_wilk_agg", {LogicalType::DOUBLE},
                                   LogicalType::ANY, // Set in bind
                                   AggregateFunction::StateSize<ShapiroWilkAggregateState>, ShapiroWilkAggInitialize,
                                   ShapiroWilkAggUpdate, ShapiroWilkAggCombine, ShapiroWilkAggFinalize,
                                   nullptr, // simple_update
                                   ShapiroWilkAggBind, ShapiroWilkAggDestroy);
-    func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_shapiro_wilk_agg");
+        func_set.AddFunction(func);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription desc;
+        desc.description     = "Performs the Shapiro-Wilk test for normality on a sample.";
+        desc.examples        = {"anofox_stats_shapiro_wilk_agg(value)"};
+        desc.categories      = {"normality-test"};
+        desc.parameter_names = {"value"};
+        desc.parameter_types = {LogicalType::DOUBLE};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Also register short alias
-    AggregateFunctionSet alias_set("shapiro_wilk_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("shapiro_wilk_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_shapiro_wilk_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/spearman_aggregate.cpp
+++ b/src/aggregate_functions/spearman_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -238,12 +239,34 @@ void RegisterSpearmanAggregateFunction(ExtensionLoader &loader) {
         nullptr, SpearmanAggBind, SpearmanAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Computes Spearman's rank correlation coefficient and tests its significance.";
+    d1.examples        = {"anofox_stats_spearman_agg(x, y, {'alternative': 'two_sided'})"};
+    d1.categories      = {"correlation"};
+    d1.parameter_names = {"x", "y", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Computes Spearman's rank correlation coefficient and tests its significance.";
+    d2.examples        = {"anofox_stats_spearman_agg(x, y)"};
+    d2.categories      = {"correlation"};
+    d2.parameter_names = {"x", "y"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
-    AggregateFunctionSet alias_set("spearman_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    // Short alias
+    {
+        AggregateFunctionSet alias_set("spearman_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_spearman_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/t_test_aggregate.cpp
+++ b/src/aggregate_functions/t_test_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -268,13 +269,34 @@ void RegisterTTestAggregateFunction(ExtensionLoader &loader) {
         nullptr, TTestAggBind, TTestAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs a two-sample t-test (Welch or Student) comparing values between two groups.";
+    d1.examples        = {"anofox_stats_t_test_agg(value, group_id, {'alternative': 'two_sided'})"};
+    d1.categories      = {"hypothesis-testing"};
+    d1.parameter_names = {"value", "group_id", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Performs a two-sample t-test (Welch or Student) comparing values between two groups, using default options.";
+    d2.examples        = {"anofox_stats_t_test_agg(value, group_id)"};
+    d2.categories      = {"hypothesis-testing"};
+    d2.parameter_names = {"value", "group_id"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("t_test_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("t_test_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_t_test_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/tost_correlation_aggregate.cpp
+++ b/src/aggregate_functions/tost_correlation_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -270,8 +271,6 @@ static unique_ptr<FunctionData> TostCorrelationAggBind(ClientContext &context, A
 // Registration
 //===--------------------------------------------------------------------===//
 void RegisterTostCorrelationAggregateFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_tost_correlation_agg");
-
     // With options: (x, y, options)
     auto func_with_opts = AggregateFunction(
         "anofox_stats_tost_correlation_agg", {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY},
@@ -279,7 +278,6 @@ void RegisterTostCorrelationAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<TostCorrelationAggregateState>, TostCorrelationAggInitialize,
         TostCorrelationAggUpdate, TostCorrelationAggCombine, TostCorrelationAggFinalize,
         nullptr, TostCorrelationAggBind, TostCorrelationAggDestroy);
-    func_set.AddFunction(func_with_opts);
 
     // Without options: (x, y)
     auto func_no_opts = AggregateFunction(
@@ -288,15 +286,40 @@ void RegisterTostCorrelationAggregateFunction(ExtensionLoader &loader) {
         AggregateFunction::StateSize<TostCorrelationAggregateState>, TostCorrelationAggInitialize,
         TostCorrelationAggUpdate, TostCorrelationAggCombine, TostCorrelationAggFinalize,
         nullptr, TostCorrelationAggBind, TostCorrelationAggDestroy);
-    func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_tost_correlation_agg");
+        func_set.AddFunction(func_with_opts);
+        func_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription d1;
+        d1.description     = "Tests equivalence of a correlation to a reference value using the TOST procedure.";
+        d1.examples        = {"anofox_stats_tost_correlation_agg(x, y, {'delta': 0.1})"};
+        d1.categories      = {"hypothesis-testing", "equivalence"};
+        d1.parameter_names = {"x", "y", "options"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY};
+        info.descriptions.push_back(std::move(d1));
+        FunctionDescription d2;
+        d2.description     = "Tests equivalence of a correlation to a reference value using the TOST procedure, using default options.";
+        d2.examples        = {"anofox_stats_tost_correlation_agg(x, y)"};
+        d2.categories      = {"hypothesis-testing", "equivalence"};
+        d2.parameter_names = {"x", "y"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE};
+        info.descriptions.push_back(std::move(d2));
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Short alias
-    AggregateFunctionSet alias_set("tost_correlation_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("tost_correlation_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_tost_correlation_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/tost_paired_aggregate.cpp
+++ b/src/aggregate_functions/tost_paired_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -279,13 +280,34 @@ void RegisterTostPairedAggregateFunction(ExtensionLoader &loader) {
         nullptr, TostPairedAggBind, TostPairedAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Tests equivalence of paired measurements using the TOST procedure.";
+    d1.examples        = {"anofox_stats_tost_paired_agg(x, y, {'delta': 0.5})"};
+    d1.categories      = {"hypothesis-testing", "equivalence"};
+    d1.parameter_names = {"x", "y", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Tests equivalence of paired measurements using the TOST procedure, using default options.";
+    d2.examples        = {"anofox_stats_tost_paired_agg(x, y)"};
+    d2.categories      = {"hypothesis-testing", "equivalence"};
+    d2.parameter_names = {"x", "y"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("tost_paired_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("tost_paired_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_tost_paired_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/tost_t_test_aggregate.cpp
+++ b/src/aggregate_functions/tost_t_test_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -277,13 +278,34 @@ void RegisterTostTTestAggregateFunction(ExtensionLoader &loader) {
         nullptr, TostTTestAggBind, TostTTestAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Tests equivalence of two groups using the Two One-Sided Tests (TOST) procedure with a t-test.";
+    d1.examples        = {"anofox_stats_tost_t_test_agg(value, group_id, {'delta': 1.0})"};
+    d1.categories      = {"hypothesis-testing", "equivalence"};
+    d1.parameter_names = {"value", "group_id", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Tests equivalence of two groups using the Two One-Sided Tests (TOST) procedure with a t-test, using default options.";
+    d2.examples        = {"anofox_stats_tost_t_test_agg(value, group_id)"};
+    d2.categories      = {"hypothesis-testing", "equivalence"};
+    d2.parameter_names = {"value", "group_id"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("tost_t_test_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("tost_t_test_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_tost_t_test_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/vif_aggregate.cpp
+++ b/src/aggregate_functions/vif_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -208,12 +209,26 @@ void RegisterVifAggregateFunction(ExtensionLoader &loader) {
                                   VifAggBind, VifAggDestroy);
     func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Aggregate version of VIF: computes Variance Inflation Factor for each feature from a column of feature vectors.";
+    d1.examples        = {"anofox_stats_vif_agg(x)"};
+    d1.categories      = {"regression-diagnostics"};
+    d1.parameter_names = {"x"};
+    d1.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+    loader.RegisterFunction(std::move(info));
 
     // Also register short alias
-    AggregateFunctionSet alias_set("vif_agg");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("vif_agg");
+        alias_set.AddFunction(func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_vif_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/wilcoxon_signed_rank_aggregate.cpp
+++ b/src/aggregate_functions/wilcoxon_signed_rank_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -261,13 +262,34 @@ void RegisterWilcoxonSignedRankAggregateFunction(ExtensionLoader &loader) {
         nullptr, WilcoxonSignedRankAggBind, WilcoxonSignedRankAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs the Wilcoxon signed-rank test for paired samples.";
+    d1.examples        = {"anofox_stats_wilcoxon_signed_rank_agg(x, y, {'alternative': 'two_sided'})"};
+    d1.categories      = {"hypothesis-testing", "nonparametric"};
+    d1.parameter_names = {"x", "y", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Performs the Wilcoxon signed-rank test for paired samples, using default options.";
+    d2.examples        = {"anofox_stats_wilcoxon_signed_rank_agg(x, y)"};
+    d2.categories      = {"hypothesis-testing", "nonparametric"};
+    d2.parameter_names = {"x", "y"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("wilcoxon_signed_rank_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("wilcoxon_signed_rank_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_wilcoxon_signed_rank_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/wls_aggregate.cpp
+++ b/src/aggregate_functions/wls_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -418,13 +419,34 @@ void RegisterWlsAggregateFunction(ExtensionLoader &loader) {
                                       WlsAggBind, WlsAggDestroy);
     func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Fits a Weighted Least Squares regression model and returns coefficients and fit statistics.";
+    d1.examples        = {"anofox_stats_wls_fit_agg(y, x, weight, {'fit_intercept': true})"};
+    d1.categories      = {"regression"};
+    d1.parameter_names = {"y", "x", "weight", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Fits a Weighted Least Squares regression model and returns coefficients and fit statistics.";
+    d2.examples        = {"anofox_stats_wls_fit_agg(y, x, weight)"};
+    d2.categories      = {"regression"};
+    d2.parameter_names = {"y", "x", "weight"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Register short alias
-    AggregateFunctionSet alias_set("wls_fit_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("wls_fit_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_wls_fit_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/wls_predict_aggregate.cpp
+++ b/src/aggregate_functions/wls_predict_aggregate.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -496,30 +497,80 @@ void RegisterWlsFitPredictAggregateFunction(ExtensionLoader &loader) {
         WlsPredictAggDestroy);
     func_set.AddFunction(split_opts_func);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+    FunctionDescription d1;
+    d1.description = "Fits WLS regression over a partition using weights and returns per-row predictions.";
+    d1.examples = {"anofox_stats_wls_fit_predict_agg(y, x, weights)"};
+    d1.categories = {"regression", "prediction"};
+    d1.parameter_names = {"y", "x", "weights"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits WLS regression over a partition using weights with a MAP of options and returns per-row predictions.";
+    d2.examples = {"anofox_stats_wls_fit_predict_agg(y, x, weights, {'null_policy': 'drop'})"};
+    d2.categories = {"regression", "prediction"};
+    d2.parameter_names = {"y", "x", "weights", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits WLS regression using only training rows (split_col='train') with weights and predicts all rows.";
+    d3.examples = {"anofox_stats_wls_fit_predict_agg(y, x, weights, split_col)"};
+    d3.categories = {"regression", "prediction"};
+    d3.parameter_names = {"y", "x", "weights", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE, LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits WLS regression on training rows with weights and a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_wls_fit_predict_agg(y, x, weights, split_col, {'null_policy': 'drop'})"};
+    d4.categories = {"regression", "prediction"};
+    d4.parameter_names = {"y", "x", "weights", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE, LogicalType::VARCHAR, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
 
     // Short alias (new)
-    AggregateFunctionSet alias_set("wls_fit_predict_agg");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    alias_set.AddFunction(split_func);
-    alias_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("wls_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_wls_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 
     // Deprecated aliases (old names for backwards compatibility)
-    AggregateFunctionSet deprecated_set("wls_predict_agg");
-    deprecated_set.AddFunction(basic_func);
-    deprecated_set.AddFunction(map_func);
-    deprecated_set.AddFunction(split_func);
-    deprecated_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(deprecated_set);
+    {
+        AggregateFunctionSet dep_set("wls_predict_agg");
+        dep_set.AddFunction(basic_func);
+        dep_set.AddFunction(map_func);
+        dep_set.AddFunction(split_func);
+        dep_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo dep_info(std::move(dep_set));
+        dep_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        dep_info.alias_of = "anofox_stats_wls_fit_predict_agg";
+        loader.RegisterFunction(std::move(dep_info));
+    }
 
-    AggregateFunctionSet deprecated_full_set("anofox_stats_wls_predict_agg");
-    deprecated_full_set.AddFunction(basic_func);
-    deprecated_full_set.AddFunction(map_func);
-    deprecated_full_set.AddFunction(split_func);
-    deprecated_full_set.AddFunction(split_opts_func);
-    loader.RegisterFunction(deprecated_full_set);
+    {
+        AggregateFunctionSet dep2_set("anofox_stats_wls_predict_agg");
+        dep2_set.AddFunction(basic_func);
+        dep2_set.AddFunction(map_func);
+        dep2_set.AddFunction(split_func);
+        dep2_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo dep2_info(std::move(dep2_set));
+        dep2_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        dep2_info.alias_of = "anofox_stats_wls_fit_predict_agg";
+        loader.RegisterFunction(std::move(dep2_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/aggregate_functions/yuen_aggregate.cpp
+++ b/src/aggregate_functions/yuen_aggregate.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -284,13 +285,34 @@ void RegisterYuenAggregateFunction(ExtensionLoader &loader) {
         nullptr, YuenAggBind, YuenAggDestroy);
     func_set.AddFunction(func_no_opts);
 
-    loader.RegisterFunction(func_set);
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description     = "Performs Yuen's trimmed-means t-test, robust to outliers and non-normality.";
+    d1.examples        = {"anofox_stats_yuen_agg(value, group_id, {'trim': 0.2})"};
+    d1.categories      = {"hypothesis-testing"};
+    d1.parameter_names = {"value", "group_id", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER, LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description     = "Performs Yuen's trimmed-means t-test, robust to outliers and non-normality, using default options.";
+    d2.examples        = {"anofox_stats_yuen_agg(value, group_id)"};
+    d2.categories      = {"hypothesis-testing"};
+    d2.parameter_names = {"value", "group_id"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::INTEGER};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
 
     // Short alias
-    AggregateFunctionSet alias_set("yuen_agg");
-    alias_set.AddFunction(func_with_opts);
-    alias_set.AddFunction(func_no_opts);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("yuen_agg");
+        alias_set.AddFunction(func_with_opts);
+        alias_set.AddFunction(func_no_opts);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_yuen_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/scalar_functions/aic_bic.cpp
+++ b/src/scalar_functions/aic_bic.cpp
@@ -2,6 +2,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -110,29 +111,58 @@ static void BicFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 // Register the functions
 void RegisterAicBicFunctions(ExtensionLoader &loader) {
-    // AIC function
-    ScalarFunctionSet aic_set("anofox_stats_aic");
-    ScalarFunction aic_func({LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::DOUBLE,
-                            AicFunction);
-    aic_set.AddFunction(aic_func);
-    loader.RegisterFunction(aic_set);
+    ScalarFunction aic_func({LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::DOUBLE, AicFunction);
+    ScalarFunction bic_func({LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::DOUBLE, BicFunction);
 
-    // AIC short alias
-    ScalarFunctionSet aic_alias("aic");
-    aic_alias.AddFunction(aic_func);
-    loader.RegisterFunction(aic_alias);
+    // AIC primary
+    {
+        ScalarFunctionSet aic_set("anofox_stats_aic");
+        aic_set.AddFunction(aic_func);
+        CreateScalarFunctionInfo info(std::move(aic_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription desc;
+        desc.description     = "Computes Akaike Information Criterion (AIC) from residual sum of squares, number of observations, and number of parameters.";
+        desc.examples        = {"anofox_stats_aic(rss, n, k)"};
+        desc.categories      = {"model-selection"};
+        desc.parameter_names = {"rss", "n", "k"};
+        desc.parameter_types = {LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::BIGINT};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    // AIC alias
+    {
+        ScalarFunctionSet alias_set("aic");
+        alias_set.AddFunction(aic_func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_aic";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 
-    // BIC function
-    ScalarFunctionSet bic_set("anofox_stats_bic");
-    ScalarFunction bic_func({LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::BIGINT}, LogicalType::DOUBLE,
-                            BicFunction);
-    bic_set.AddFunction(bic_func);
-    loader.RegisterFunction(bic_set);
-
-    // BIC short alias
-    ScalarFunctionSet bic_alias("bic");
-    bic_alias.AddFunction(bic_func);
-    loader.RegisterFunction(bic_alias);
+    // BIC primary
+    {
+        ScalarFunctionSet bic_set("anofox_stats_bic");
+        bic_set.AddFunction(bic_func);
+        CreateScalarFunctionInfo info(std::move(bic_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription desc;
+        desc.description     = "Computes Bayesian Information Criterion (BIC) from residual sum of squares, number of observations, and number of parameters.";
+        desc.examples        = {"anofox_stats_bic(rss, n, k)"};
+        desc.categories      = {"model-selection"};
+        desc.parameter_names = {"rss", "n", "k"};
+        desc.parameter_types = {LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::BIGINT};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    // BIC alias
+    {
+        ScalarFunctionSet alias_set("bic");
+        alias_set.AddFunction(bic_func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_bic";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/scalar_functions/jarque_bera.cpp
+++ b/src/scalar_functions/jarque_bera.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -95,19 +96,34 @@ static void JarqueBeraFunction(DataChunk &args, ExpressionState &state, Vector &
 
 // Register the function
 void RegisterJarqueBeraFunction(ExtensionLoader &loader) {
-    ScalarFunctionSet func_set("anofox_stats_jarque_bera");
-
     auto func = ScalarFunction({LogicalType::LIST(LogicalType::DOUBLE)},
-                               LogicalType::ANY, // Set in bind
+                               LogicalType::ANY,
                                JarqueBeraFunction, JarqueBeraBind);
-    func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
-
-    // Also register short alias
-    ScalarFunctionSet alias_set("jarque_bera");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    // Primary
+    {
+        ScalarFunctionSet func_set("anofox_stats_jarque_bera");
+        func_set.AddFunction(func);
+        CreateScalarFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription desc;
+        desc.description     = "Tests whether a sample has skewness and kurtosis consistent with a normal distribution (Jarque-Bera test).";
+        desc.examples        = {"anofox_stats_jarque_bera(values)"};
+        desc.categories      = {"normality-test"};
+        desc.parameter_names = {"values"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE)};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    // Alias
+    {
+        ScalarFunctionSet alias_set("jarque_bera");
+        alias_set.AddFunction(func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_jarque_bera";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/scalar_functions/residuals_diagnostics.cpp
+++ b/src/scalar_functions/residuals_diagnostics.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -192,28 +193,52 @@ static void ResidualsDiagnosticsFunction(DataChunk &args, ExpressionState &state
 
 // Register the function
 void RegisterResidualsDiagnosticsFunction(ExtensionLoader &loader) {
-    ScalarFunctionSet func_set("anofox_stats_residuals_diagnostics");
-
-    // Basic version: anofox_stats_residuals_diagnostics(y, y_hat)
     auto basic_func = ScalarFunction({LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::DOUBLE)},
-                                     LogicalType::ANY, // Set in bind
+                                     LogicalType::ANY,
                                      ResidualsDiagnosticsFunction, ResidualsDiagnosticsBind);
-    func_set.AddFunction(basic_func);
-
-    // Full version: anofox_stats_residuals_diagnostics(y, y_hat, x, residual_std_error, include_studentized)
     auto full_func = ScalarFunction({LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::DOUBLE),
                                      LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::DOUBLE,
                                      LogicalType::BOOLEAN},
                                     LogicalType::ANY, ResidualsDiagnosticsFunction, ResidualsDiagnosticsBind);
-    func_set.AddFunction(full_func);
 
-    loader.RegisterFunction(func_set);
+    // Primary (2 overloads)
+    {
+        ScalarFunctionSet func_set("anofox_stats_residuals_diagnostics");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(full_func);
+        CreateScalarFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    // Also register short alias
-    ScalarFunctionSet alias_set("residuals_diagnostics");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(full_func);
-    loader.RegisterFunction(alias_set);
+        FunctionDescription d1;
+        d1.description     = "Computes raw and standardized residuals, leverage, and Cook's distance from actuals and predictions.";
+        d1.examples        = {"anofox_stats_residuals_diagnostics(y, y_hat)"};
+        d1.categories      = {"regression-diagnostics"};
+        d1.parameter_names = {"y", "y_hat"};
+        d1.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::DOUBLE)};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Computes residual diagnostics including studentized residuals when feature matrix and residual standard error are supplied.";
+        d2.examples        = {"anofox_stats_residuals_diagnostics(y, y_hat, x, rse, true)"};
+        d2.categories      = {"regression-diagnostics"};
+        d2.parameter_names = {"y", "y_hat", "x", "residual_std_error", "include_studentized"};
+        d2.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::DOUBLE),
+                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::DOUBLE,
+                              LogicalType::BOOLEAN};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+    // Alias
+    {
+        ScalarFunctionSet alias_set("residuals_diagnostics");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(full_func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_residuals_diagnostics";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/scalar_functions/vif.cpp
+++ b/src/scalar_functions/vif.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
@@ -89,19 +90,33 @@ static void VifFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 // Register the function
 void RegisterVifFunction(ExtensionLoader &loader) {
-    ScalarFunctionSet func_set("anofox_stats_vif");
-
-    // anofox_stats_vif(x) -> LIST(DOUBLE)
     ScalarFunction func({LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
                         LogicalType::LIST(LogicalType::DOUBLE), VifFunction);
-    func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
-
-    // Also register short alias
-    ScalarFunctionSet alias_set("vif");
-    alias_set.AddFunction(func);
-    loader.RegisterFunction(alias_set);
+    // Primary
+    {
+        ScalarFunctionSet func_set("anofox_stats_vif");
+        func_set.AddFunction(func);
+        CreateScalarFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        FunctionDescription desc;
+        desc.description     = "Computes Variance Inflation Factor (VIF) for each column of a feature matrix to detect multicollinearity.";
+        desc.examples        = {"anofox_stats_vif(x)"};
+        desc.categories      = {"regression-diagnostics"};
+        desc.parameter_names = {"x"};
+        desc.parameter_types = {LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))};
+        info.descriptions.push_back(std::move(desc));
+        loader.RegisterFunction(std::move(info));
+    }
+    // Alias
+    {
+        ScalarFunctionSet alias_set("vif");
+        alias_set.AddFunction(func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_vif";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/elasticnet_fit.cpp
+++ b/src/table_functions/elasticnet_fit.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 #include "../include/anofox_stats_ffi.h"
@@ -203,29 +204,52 @@ static void ElasticNetFitFunction(DataChunk &args, ExpressionState &state, Vecto
 
 // Register the function
 void RegisterElasticNetFitFunction(ExtensionLoader &loader) {
-    ScalarFunctionSet func_set("anofox_stats_elasticnet_fit");
-
-    // Basic version: anofox_stats_elasticnet_fit(y, x) - uses default alpha=1.0, l1_ratio=0.5
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
-        LogicalType::ANY, // Will be set in bind
+        LogicalType::ANY,
         ElasticNetFitFunction, ElasticNetFitBind);
-    func_set.AddFunction(basic_func);
 
-    // Version with MAP options: anofox_stats_elasticnet_fit(y, x, {'alpha': 1.0, 'l1_ratio': 0.5, ...})
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
-                             LogicalType::ANY}, // MAP or STRUCT for options
+                             LogicalType::ANY},
                             LogicalType::ANY, ElasticNetFitFunction, ElasticNetFitBind);
-    func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    // Primary
+    {
+        ScalarFunctionSet func_set("anofox_stats_elasticnet_fit");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateScalarFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    // Register short alias
-    ScalarFunctionSet alias_set("elasticnet_fit");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+        FunctionDescription d1;
+        d1.description     = "Fits an ElasticNet regression model combining L1 and L2 regularization to the given response and feature data.";
+        d1.examples        = {"anofox_stats_elasticnet_fit(y, x)"};
+        d1.categories      = {"regression"};
+        d1.parameter_names = {"y", "x"};
+        d1.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Fits an ElasticNet regression model (L1+L2 regularization) with optional MAP of settings (fit_intercept, alpha, l1_ratio, max_iterations, tolerance).";
+        d2.examples        = {"anofox_stats_elasticnet_fit(y, x, {'alpha': 1.0, 'l1_ratio': 0.5})"};
+        d2.categories      = {"regression"};
+        d2.parameter_names = {"y", "x", "options"};
+        d2.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+    // Alias
+    {
+        ScalarFunctionSet alias_set("elasticnet_fit");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_elasticnet_fit";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/ols_fit.cpp
+++ b/src/table_functions/ols_fit.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 #include "../include/anofox_stats_ffi.h"
@@ -232,29 +233,52 @@ static void OlsFitFunction(DataChunk &args, ExpressionState &state, Vector &resu
 
 // Register the function
 void RegisterOlsFitFunction(ExtensionLoader &loader) {
-    ScalarFunctionSet func_set("anofox_stats_ols_fit");
-
-    // Basic version: anofox_stats_ols_fit(y, x) - uses defaults
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
-        LogicalType::ANY, // Will be set in bind
+        LogicalType::ANY,
         OlsFitFunction, OlsFitBind);
-    func_set.AddFunction(basic_func);
 
-    // Version with MAP options: anofox_stats_ols_fit(y, x, {'intercept': true, ...})
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
-                             LogicalType::ANY}, // MAP or STRUCT for options
+                             LogicalType::ANY},
                             LogicalType::ANY, OlsFitFunction, OlsFitBind);
-    func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    // Primary
+    {
+        ScalarFunctionSet func_set("anofox_stats_ols_fit");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateScalarFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    // Register short alias
-    ScalarFunctionSet alias_set("ols_fit");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+        FunctionDescription d1;
+        d1.description     = "Fits an Ordinary Least Squares (OLS) regression model to the given response and feature data.";
+        d1.examples        = {"anofox_stats_ols_fit(y, x)"};
+        d1.categories      = {"regression"};
+        d1.parameter_names = {"y", "x"};
+        d1.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Fits an OLS regression model with optional MAP of settings (fit_intercept, compute_inference, confidence_level, solver, hc_type).";
+        d2.examples        = {"anofox_stats_ols_fit(y, x, {'compute_inference': true, 'confidence_level': 0.95})"};
+        d2.categories      = {"regression"};
+        d2.parameter_names = {"y", "x", "options"};
+        d2.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+    // Alias
+    {
+        ScalarFunctionSet alias_set("ols_fit");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_ols_fit";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/predict.cpp
+++ b/src/table_functions/predict.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 #include "../include/anofox_stats_ffi.h"
@@ -107,18 +108,23 @@ static void PredictFunction(DataChunk &args, ExpressionState &state, Vector &res
 
 // Register the function
 void RegisterPredictFunction(ExtensionLoader &loader) {
-    ScalarFunctionSet func_set("anofox_stats_predict");
-
-    // anofox_stats_predict(x, coefficients, intercept)
-    // x: LIST(LIST(DOUBLE)) - feature data (list of feature columns, each a list of values)
-    // coefficients: LIST(DOUBLE) - fitted coefficients
-    // intercept: DOUBLE - intercept value (can be NULL)
     ScalarFunction func({LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
                          LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE},
                         LogicalType::LIST(LogicalType::DOUBLE), PredictFunction);
-    func_set.AddFunction(func);
 
-    loader.RegisterFunction(func_set);
+    ScalarFunctionSet func_set("anofox_stats_predict");
+    func_set.AddFunction(func);
+    CreateScalarFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription desc;
+    desc.description     = "Applies pre-fitted coefficients and intercept to feature data to generate predictions.";
+    desc.examples        = {"anofox_stats_predict(x, coefficients, intercept)"};
+    desc.categories      = {"regression", "prediction"};
+    desc.parameter_names = {"x", "coefficients", "intercept"};
+    desc.parameter_types = {LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
+                            LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE};
+    info.descriptions.push_back(std::move(desc));
+    loader.RegisterFunction(std::move(info));
 }
 
 } // namespace duckdb

--- a/src/table_functions/ridge_fit.cpp
+++ b/src/table_functions/ridge_fit.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 #include "../include/anofox_stats_ffi.h"
@@ -241,29 +242,52 @@ static void RidgeFitFunction(DataChunk &args, ExpressionState &state, Vector &re
 
 // Register the function
 void RegisterRidgeFitFunction(ExtensionLoader &loader) {
-    ScalarFunctionSet func_set("anofox_stats_ridge_fit");
-
-    // Basic version: anofox_stats_ridge_fit(y, x) - uses default alpha=1.0
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
-        LogicalType::ANY, // Will be set in bind
+        LogicalType::ANY,
         RidgeFitFunction, RidgeFitBind);
-    func_set.AddFunction(basic_func);
 
-    // Version with MAP options: anofox_stats_ridge_fit(y, x, {'alpha': 1.0, 'intercept': true, ...})
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
-                             LogicalType::ANY}, // MAP or STRUCT for options
+                             LogicalType::ANY},
                             LogicalType::ANY, RidgeFitFunction, RidgeFitBind);
-    func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    // Primary
+    {
+        ScalarFunctionSet func_set("anofox_stats_ridge_fit");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateScalarFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    // Register short alias
-    ScalarFunctionSet alias_set("ridge_fit");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+        FunctionDescription d1;
+        d1.description     = "Fits a Ridge regression model with L2 regularization to the given response and feature data.";
+        d1.examples        = {"anofox_stats_ridge_fit(y, x)"};
+        d1.categories      = {"regression"};
+        d1.parameter_names = {"y", "x"};
+        d1.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Fits a Ridge regression model with L2 regularization and optional MAP of settings (fit_intercept, compute_inference, confidence_level, alpha, solver).";
+        d2.examples        = {"anofox_stats_ridge_fit(y, x, {'alpha': 1.0, 'compute_inference': true})"};
+        d2.categories      = {"regression"};
+        d2.parameter_names = {"y", "x", "options"};
+        d2.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+    // Alias
+    {
+        ScalarFunctionSet alias_set("ridge_fit");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_ridge_fit";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/rls_fit.cpp
+++ b/src/table_functions/rls_fit.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 #include "../include/anofox_stats_ffi.h"
@@ -184,29 +185,52 @@ static void RlsFitFunction(DataChunk &args, ExpressionState &state, Vector &resu
 
 // Register the function
 void RegisterRlsFitFunction(ExtensionLoader &loader) {
-    ScalarFunctionSet func_set("anofox_stats_rls_fit");
-
-    // Basic version: anofox_stats_rls_fit(y, x) - uses defaults
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
-        LogicalType::ANY, // Set in bind
+        LogicalType::ANY,
         RlsFitFunction, RlsFitBind);
-    func_set.AddFunction(basic_func);
 
-    // Version with MAP options: anofox_stats_rls_fit(y, x, {'forgetting_factor': 0.99, ...})
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
-                             LogicalType::ANY}, // MAP or STRUCT for options
+                             LogicalType::ANY},
                             LogicalType::ANY, RlsFitFunction, RlsFitBind);
-    func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    // Primary
+    {
+        ScalarFunctionSet func_set("anofox_stats_rls_fit");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateScalarFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    // Register short alias
-    ScalarFunctionSet alias_set("rls_fit");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+        FunctionDescription d1;
+        d1.description     = "Fits a Recursive Least Squares (RLS) model to the given response and feature data.";
+        d1.examples        = {"anofox_stats_rls_fit(y, x)"};
+        d1.categories      = {"regression"};
+        d1.parameter_names = {"y", "x"};
+        d1.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Fits a Recursive Least Squares (RLS) model with optional MAP of settings (fit_intercept, forgetting_factor, initial_p_diagonal).";
+        d2.examples        = {"anofox_stats_rls_fit(y, x, {'forgetting_factor': 0.99})"};
+        d2.categories      = {"regression"};
+        d2.parameter_names = {"y", "x", "options"};
+        d2.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+    // Alias
+    {
+        ScalarFunctionSet alias_set("rls_fit");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_rls_fit";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/table_functions/wls_fit.cpp
+++ b/src/table_functions/wls_fit.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 
 #include "../include/anofox_stats_ffi.h"
@@ -241,31 +242,58 @@ static void WlsFitFunction(DataChunk &args, ExpressionState &state, Vector &resu
 
 // Register the function
 void RegisterWlsFitFunction(ExtensionLoader &loader) {
-    ScalarFunctionSet func_set("anofox_stats_wls_fit");
-
-    // Basic version: anofox_stats_wls_fit(y, x, weights) - uses defaults
     ScalarFunction basic_func({LogicalType::LIST(LogicalType::DOUBLE),
                                LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
                                LogicalType::LIST(LogicalType::DOUBLE)},
-                              LogicalType::ANY, // Will be set in bind
+                              LogicalType::ANY,
                               WlsFitFunction, WlsFitBind);
-    func_set.AddFunction(basic_func);
-
-    // Version with MAP options: anofox_stats_wls_fit(y, x, weights, {'intercept': true, ...})
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
                              LogicalType::LIST(LogicalType::DOUBLE),
-                             LogicalType::ANY}, // MAP or STRUCT for options
+                             LogicalType::ANY},
                             LogicalType::ANY, WlsFitFunction, WlsFitBind);
-    func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    // Primary
+    {
+        ScalarFunctionSet func_set("anofox_stats_wls_fit");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateScalarFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    // Register short alias
-    ScalarFunctionSet alias_set("wls_fit");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+        FunctionDescription d1;
+        d1.description     = "Fits a Weighted Least Squares (WLS) regression model using per-observation weights.";
+        d1.examples        = {"anofox_stats_wls_fit(y, x, weights)"};
+        d1.categories      = {"regression"};
+        d1.parameter_names = {"y", "x", "weights"};
+        d1.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE),
+                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
+                              LogicalType::LIST(LogicalType::DOUBLE)};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Fits a WLS regression model with optional MAP of settings (fit_intercept, compute_inference, confidence_level, solver, hc_type).";
+        d2.examples        = {"anofox_stats_wls_fit(y, x, weights, {'compute_inference': true})"};
+        d2.categories      = {"regression"};
+        d2.parameter_names = {"y", "x", "weights", "options"};
+        d2.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE),
+                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
+                              LogicalType::LIST(LogicalType::DOUBLE),
+                              LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+    // Alias
+    {
+        ScalarFunctionSet alias_set("wls_fit");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_wls_fit";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/window_functions/elasticnet_fit_predict.cpp
+++ b/src/window_functions/elasticnet_fit_predict.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -324,14 +325,11 @@ static unique_ptr<FunctionData> ElasticNetFitPredictBind(ClientContext &context,
 }
 
 void RegisterElasticNetFitPredictFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_elasticnet_fit_predict");
-
     auto basic_func = AggregateFunction(
         "anofox_stats_elasticnet_fit_predict", {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)},
         GetElasticNetFitPredictResultType(), AggregateFunction::StateSize<ElasticNetFitPredictState>,
         ElasticNetFitPredictInitialize, ElasticNetFitPredictUpdate, ElasticNetFitPredictCombine,
         ElasticNetFitPredictFinalize, nullptr, ElasticNetFitPredictBind, ElasticNetFitPredictDestroy);
-    func_set.AddFunction(basic_func);
 
     auto map_func = AggregateFunction(
         "anofox_stats_elasticnet_fit_predict",
@@ -339,14 +337,42 @@ void RegisterElasticNetFitPredictFunction(ExtensionLoader &loader) {
         GetElasticNetFitPredictResultType(), AggregateFunction::StateSize<ElasticNetFitPredictState>,
         ElasticNetFitPredictInitialize, ElasticNetFitPredictUpdate, ElasticNetFitPredictCombine,
         ElasticNetFitPredictFinalize, nullptr, ElasticNetFitPredictBind, ElasticNetFitPredictDestroy);
-    func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_elasticnet_fit_predict");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    AggregateFunctionSet alias_set("elasticnet_fit_predict");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+        FunctionDescription d1;
+        d1.description     = "Fits an ElasticNet regression model over a window partition and returns predictions with confidence intervals.";
+        d1.examples        = {"anofox_stats_elasticnet_fit_predict(y, x)"};
+        d1.categories      = {"regression", "prediction"};
+        d1.parameter_names = {"y", "x"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Fits an ElasticNet regression model over a window partition and returns predictions with confidence intervals.";
+        d2.examples        = {"anofox_stats_elasticnet_fit_predict(y, x, {'null_policy': 'drop'})"};
+        d2.categories      = {"regression", "prediction"};
+        d2.parameter_names = {"y", "x", "options"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+
+    {
+        AggregateFunctionSet alias_set("elasticnet_fit_predict");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_elasticnet_fit_predict";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/window_functions/ols_fit_predict.cpp
+++ b/src/window_functions/ols_fit_predict.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -357,8 +358,6 @@ static unique_ptr<FunctionData> OlsFitPredictBind(ClientContext &context, Aggreg
 // Registration
 //===--------------------------------------------------------------------===//
 void RegisterOlsFitPredictFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_ols_fit_predict");
-
     auto basic_func =
         AggregateFunction("anofox_stats_ols_fit_predict",
                           {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)}, GetOlsFitPredictResultType(),
@@ -366,22 +365,49 @@ void RegisterOlsFitPredictFunction(ExtensionLoader &loader) {
                           OlsFitPredictUpdate, OlsFitPredictCombine, OlsFitPredictFinalize,
                           nullptr, // simple_update
                           OlsFitPredictBind, OlsFitPredictDestroy);
-    func_set.AddFunction(basic_func);
 
     auto map_func = AggregateFunction("anofox_stats_ols_fit_predict",
                                       {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY},
                                       GetOlsFitPredictResultType(), AggregateFunction::StateSize<OlsFitPredictState>,
                                       OlsFitPredictInitialize, OlsFitPredictUpdate, OlsFitPredictCombine,
                                       OlsFitPredictFinalize, nullptr, OlsFitPredictBind, OlsFitPredictDestroy);
-    func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_ols_fit_predict");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+        FunctionDescription d1;
+        d1.description     = "Fits an OLS model over a window partition and returns predictions for each row, including confidence intervals.";
+        d1.examples        = {"anofox_stats_ols_fit_predict(y, x)"};
+        d1.categories      = {"regression", "prediction"};
+        d1.parameter_names = {"y", "x"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Fits an OLS model over a window partition and returns predictions for each row, including confidence intervals.";
+        d2.examples        = {"anofox_stats_ols_fit_predict(y, x, {'null_policy': 'drop'})"};
+        d2.categories      = {"regression", "prediction"};
+        d2.parameter_names = {"y", "x", "options"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
 
     // Register short alias
-    AggregateFunctionSet alias_set("ols_fit_predict");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+    {
+        AggregateFunctionSet alias_set("ols_fit_predict");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_ols_fit_predict";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/window_functions/ridge_fit_predict.cpp
+++ b/src/window_functions/ridge_fit_predict.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -308,15 +309,12 @@ static unique_ptr<FunctionData> RidgeFitPredictBind(ClientContext &context, Aggr
 }
 
 void RegisterRidgeFitPredictFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_ridge_fit_predict");
-
     auto basic_func =
         AggregateFunction("anofox_stats_ridge_fit_predict",
                           {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)}, GetRidgeFitPredictResultType(),
                           AggregateFunction::StateSize<RidgeFitPredictState>, RidgeFitPredictInitialize,
                           RidgeFitPredictUpdate, RidgeFitPredictCombine, RidgeFitPredictFinalize, nullptr,
                           RidgeFitPredictBind, RidgeFitPredictDestroy);
-    func_set.AddFunction(basic_func);
 
     auto map_func =
         AggregateFunction("anofox_stats_ridge_fit_predict",
@@ -324,14 +322,42 @@ void RegisterRidgeFitPredictFunction(ExtensionLoader &loader) {
                           GetRidgeFitPredictResultType(), AggregateFunction::StateSize<RidgeFitPredictState>,
                           RidgeFitPredictInitialize, RidgeFitPredictUpdate, RidgeFitPredictCombine,
                           RidgeFitPredictFinalize, nullptr, RidgeFitPredictBind, RidgeFitPredictDestroy);
-    func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_ridge_fit_predict");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    AggregateFunctionSet alias_set("ridge_fit_predict");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+        FunctionDescription d1;
+        d1.description     = "Fits a Ridge regression model over a window partition and returns predictions with confidence intervals.";
+        d1.examples        = {"anofox_stats_ridge_fit_predict(y, x)"};
+        d1.categories      = {"regression", "prediction"};
+        d1.parameter_names = {"y", "x"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Fits a Ridge regression model over a window partition and returns predictions with confidence intervals.";
+        d2.examples        = {"anofox_stats_ridge_fit_predict(y, x, {'null_policy': 'drop'})"};
+        d2.categories      = {"regression", "prediction"};
+        d2.parameter_names = {"y", "x", "options"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+
+    {
+        AggregateFunctionSet alias_set("ridge_fit_predict");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_ridge_fit_predict";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/window_functions/rls_fit_predict.cpp
+++ b/src/window_functions/rls_fit_predict.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
@@ -293,15 +294,12 @@ static unique_ptr<FunctionData> RlsFitPredictBind(ClientContext &context, Aggreg
 }
 
 void RegisterRlsFitPredictFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_rls_fit_predict");
-
     auto basic_func =
         AggregateFunction("anofox_stats_rls_fit_predict",
                           {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)}, GetRlsFitPredictResultType(),
                           AggregateFunction::StateSize<RlsFitPredictState>, RlsFitPredictInitialize,
                           RlsFitPredictUpdate, RlsFitPredictCombine, RlsFitPredictFinalize, nullptr,
                           RlsFitPredictBind, RlsFitPredictDestroy);
-    func_set.AddFunction(basic_func);
 
     auto map_func =
         AggregateFunction("anofox_stats_rls_fit_predict",
@@ -309,14 +307,42 @@ void RegisterRlsFitPredictFunction(ExtensionLoader &loader) {
                           GetRlsFitPredictResultType(), AggregateFunction::StateSize<RlsFitPredictState>,
                           RlsFitPredictInitialize, RlsFitPredictUpdate, RlsFitPredictCombine, RlsFitPredictFinalize,
                           nullptr, RlsFitPredictBind, RlsFitPredictDestroy);
-    func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_rls_fit_predict");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    AggregateFunctionSet alias_set("rls_fit_predict");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+        FunctionDescription d1;
+        d1.description     = "Fits a Robust Least Squares model over a window partition and returns predictions with confidence intervals.";
+        d1.examples        = {"anofox_stats_rls_fit_predict(y, x)"};
+        d1.categories      = {"regression", "prediction"};
+        d1.parameter_names = {"y", "x"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Fits a Robust Least Squares model over a window partition and returns predictions with confidence intervals.";
+        d2.examples        = {"anofox_stats_rls_fit_predict(y, x, {'null_policy': 'drop'})"};
+        d2.categories      = {"regression", "prediction"};
+        d2.parameter_names = {"y", "x", "options"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+
+    {
+        AggregateFunctionSet alias_set("rls_fit_predict");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_rls_fit_predict";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb

--- a/src/window_functions/wls_fit_predict.cpp
+++ b/src/window_functions/wls_fit_predict.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/function/aggregate_function.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
 
 #include "../include/anofox_stats_ffi.h"
 #include "../include/ffi_enum_converters.hpp"
@@ -310,8 +311,6 @@ static unique_ptr<FunctionData> WlsFitPredictBind(ClientContext &context, Aggreg
 }
 
 void RegisterWlsFitPredictFunction(ExtensionLoader &loader) {
-    AggregateFunctionSet func_set("anofox_stats_wls_fit_predict");
-
     // WLS takes (y, x, weight)
     auto basic_func = AggregateFunction(
         "anofox_stats_wls_fit_predict",
@@ -319,7 +318,6 @@ void RegisterWlsFitPredictFunction(ExtensionLoader &loader) {
         GetWlsFitPredictResultType(), AggregateFunction::StateSize<WlsFitPredictState>, WlsFitPredictInitialize,
         WlsFitPredictUpdate, WlsFitPredictCombine, WlsFitPredictFinalize, nullptr, WlsFitPredictBind,
         WlsFitPredictDestroy);
-    func_set.AddFunction(basic_func);
 
     auto map_func = AggregateFunction(
         "anofox_stats_wls_fit_predict",
@@ -327,14 +325,42 @@ void RegisterWlsFitPredictFunction(ExtensionLoader &loader) {
         GetWlsFitPredictResultType(), AggregateFunction::StateSize<WlsFitPredictState>, WlsFitPredictInitialize,
         WlsFitPredictUpdate, WlsFitPredictCombine, WlsFitPredictFinalize, nullptr, WlsFitPredictBind,
         WlsFitPredictDestroy);
-    func_set.AddFunction(map_func);
 
-    loader.RegisterFunction(func_set);
+    {
+        AggregateFunctionSet func_set("anofox_stats_wls_fit_predict");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
 
-    AggregateFunctionSet alias_set("wls_fit_predict");
-    alias_set.AddFunction(basic_func);
-    alias_set.AddFunction(map_func);
-    loader.RegisterFunction(alias_set);
+        FunctionDescription d1;
+        d1.description     = "Fits a WLS regression model over a window partition using per-row weights and returns predictions.";
+        d1.examples        = {"anofox_stats_wls_fit_predict(y, x, weight)"};
+        d1.categories      = {"regression", "prediction"};
+        d1.parameter_names = {"y", "x", "weight"};
+        d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description     = "Fits a WLS regression model over a window partition using per-row weights and returns predictions.";
+        d2.examples        = {"anofox_stats_wls_fit_predict(y, x, weight, {'null_policy': 'drop'})"};
+        d2.categories      = {"regression", "prediction"};
+        d2.parameter_names = {"y", "x", "weight", "options"};
+        d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE, LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+
+    {
+        AggregateFunctionSet alias_set("wls_fit_predict");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_wls_fit_predict";
+        loader.RegisterFunction(std::move(alias_info));
+    }
 }
 
 } // namespace duckdb


### PR DESCRIPTION
## Summary

- Adds `description`, `examples`, `categories`, `parameter_names`, and `parameter_types` to every public-facing function so that `SELECT * FROM duckdb_functions()` returns complete documentation
- Wraps all `loader.RegisterFunction(FunctionSet)` calls with `CreateScalarFunctionInfo` / `CreateAggregateFunctionInfo` and attaches populated `FunctionDescription` entries
- Alias registrations (short names like `aic`, `t_test_agg`) set `alias_of` pointing to the canonical `anofox_stats_*` name
- Deprecated aliases (`ols_predict_agg`, `anofox_stats_ols_predict_agg`, etc.) also set `alias_of` for correct catalog linkage

## Coverage (verified via `duckdb_functions()`)

| function_type | total | has_desc | has_alias_of |
|---|---|---|---|
| aggregate | 160 | 140 | 20 |
| scalar | 17 | 17 | 0 |

All 140 non-alias aggregate rows and all 17 scalar rows have descriptions. The 20 `has_alias_of` aggregate rows are the deprecated `anofox_stats_*_predict_agg` aliases — correctly linked, no description needed.

## Files changed

- `src/scalar_functions/` — 4 files
- `src/table_functions/` — 6 files  
- `src/window_functions/` — 5 files
- `src/aggregate_functions/` — 58 files

`src/macros/fit_predict_macros.cpp` — no changes (macros registered with `internal = true`, not visible in `duckdb_functions()`)

## Test plan

- [x] `make -j$(nproc)` — clean build, zero errors
- [x] `SELECT * FROM duckdb_functions() WHERE function_name LIKE 'anofox_stats_%'` — all primary functions have description, examples, categories, parameter_types
- [x] Spot-checked `anofox_stats_t_test_agg` (2 overloads, distinct parameter_types per row), `anofox_stats_aic` (description populated), `aic` (alias_of set, no description)