### PR TITLE
Publish extension to erpl.io distribution bucket

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+# OIDC token needed for AWS credentials in the deploy job.
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true
@@ -22,6 +27,17 @@ jobs:
       enable_rust: true
       reduced_ci_mode: disabled
 
+  duckdb-stable-deploy:
+    name: Deploy extension binaries (v1.5.3)
+    needs: duckdb-stable-build
+    uses: ./.github/workflows/_extension_deploy.yml
+    secrets: inherit
+    with:
+      duckdb_version: v1.5.3
+      extension_name: anofox_statistics
+      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+      deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+
   duckdb-v144-build:
     name: Build extension binaries (DuckDB v1.4.4)
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4.4
@@ -31,6 +47,17 @@ jobs:
       extension_name: anofox_statistics
       enable_rust: true
       reduced_ci_mode: disabled
+
+  duckdb-v144-deploy:
+    name: Deploy extension binaries (v1.4.4 LTS)
+    needs: duckdb-v144-build
+    uses: ./.github/workflows/_extension_deploy.yml
+    secrets: inherit
+    with:
+      duckdb_version: v1.4.4
+      extension_name: anofox_statistics
+      deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+      deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 
   build-and-test-rust:
     name: Build and test Rust components

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -64,11 +64,23 @@ jobs:
       - name: Checkout DuckDB to version
         run: |
           cd duckdb
+          git fetch --depth 1 origin tag ${{ inputs.duckdb_version }}
           git checkout ${{ inputs.duckdb_version }}
+
+      - name: Checkout extension-ci-tools to version
+        # Submodules are pinned to the stable DuckDB version; for the
+        # LTS deploy we need the matching tools so the parsed
+        # architecture matrix lines up with what the LTS build job
+        # produced. Branch first, tag fallback.
+        run: |
+          cd extension-ci-tools
+          git fetch --depth 1 origin ${{ inputs.duckdb_version }} || \
+            git fetch --depth 1 origin tag ${{ inputs.duckdb_version }}
+          git checkout FETCH_HEAD
 
       - id: parse-matrices
         run: |
-          python3 ${{ inputs.matrix_parse_script }} --input ./extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input ./extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --reduced_ci_mode auto --pretty
           deploy_matrix="`cat deploy_matrix.json`"
           echo deploy_matrix=$deploy_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`

--- a/README.md
+++ b/README.md
@@ -169,6 +169,21 @@ SELECT * FROM ridge_fit_predict_by(
 
 ## Installation
 
+### From erpl.io (recommended)
+
+Install directly from our public distribution bucket. DuckDB must be started
+with the `-unsigned` flag, since the extension binary is not signed by the
+DuckDB Foundation:
+
+```sql
+INSTALL 'anofox_statistics' FROM 'http://get.erpl.io';
+LOAD 'anofox_statistics';
+```
+
+This pulls the right binary for your platform (Linux amd64/arm64, macOS
+amd64/arm64, Windows amd64). No build toolchain, no vcpkg, no submodules
+required.
+
 ### Community Extension
 
 ```sql


### PR DESCRIPTION
Closes #57.

## Summary
- Wire the existing `_extension_deploy.yml` into `MainDistributionPipeline.yml` for both v1.5.3 (stable) and v1.4.4 (LTS). Deploy fires on tag pushes and on `main`; PRs build but don't publish, matching the quack-oauth pattern.
- Add `permissions: id-token: write` at the workflow level so the deploy job can assume the erpl OIDC role.
- Document the new install path in `README.md`:
  ```sql
  INSTALL 'anofox_statistics' FROM 'http://get.erpl.io';
  LOAD 'anofox_statistics';
  ```
  with the `-unsigned` flag caveat.

## Prerequisites for the publish path to work end-to-end
- `DEPLOY_S3_BUCKET` is already set at the repo level to `get.erpl.io`. ✅
- The OIDC role `ErplGithubOicdRole` must trust this repo's `sub` (already trusted for sibling extensions like quack-oauth / erpl-web — verify it covers `DataZooDE/anofox-statistics` too, or add it).
- After merge: first push to `main` triggers `duckdb-stable-deploy` and uploads the v1.5.3 binaries.

## Test plan
- [ ] Confirm CI green on the PR (build jobs only; deploy is gated on tag/main and will be skipped on the PR).
- [ ] After merge to `main`, confirm `duckdb-stable-deploy` succeeds and binaries land in `s3://get.erpl.io/v1.5.3/<arch>/anofox_statistics.duckdb_extension.gz`.
- [ ] Smoke test from a clean DuckDB shell started with `-unsigned`:
  ```sql
  INSTALL 'anofox_statistics' FROM 'http://get.erpl.io';
  LOAD 'anofox_statistics';
  SELECT * FROM ols_fit([1.0,2.0,3.0]::DOUBLE[], [[1.0],[2.0],[3.0]]::DOUBLE[][], MAP{'intercept': true});
  ```
- [ ] Note: v1.4.4 LTS deploy will publish once unrelated pre-existing mingw/macOS LTS build flakes on `main` clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)