### PR TITLE
Bump anofox-regression to 0.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anofox-regression"
-version = "0.5.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759da17c46046656d41db693a1b19b150820e9e10897c2ea89369a5738ce9790"
+checksum = "83196428371fd4134cca085693bfab52e1e63799d67bb9f7ac633b3b445c97ea"
 dependencies = [
  "argmin",
  "argmin-math",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Simon M"]
 repository = "https://github.com/DataZooDE/anofox-statistics"
 
 [workspace.dependencies]
-anofox-regression = "0.5.2"
+anofox-regression = "0.5.7"
 anofox-tests = { package = "anofox-statistics", version = "0.4.2" }
 # faer: disable default features (which include rayon) - DuckDB handles parallelization
 faer = { version = "0.23", default-features = false, features = ["std", "linalg"] }


### PR DESCRIPTION
Prerequisite for #60, #61, #62, #63.

## Summary
- \`anofox-regression\` workspace pin **0.5.2 → 0.5.7**.
- Unlocks 8 new solver modules in the crate (Huber, RANSAC, Theil-Sen, BayesianRidge, ARD, LARS, Logistic, Gamma, PassiveAggressive) that the upcoming estimator-wiring PRs surface in SQL.
- 0.5.7 specifically replaces `is_multiple_of` (unstable on Rust < 1.87) with `n % 2 == 0` in `solvers/huber.rs` and `solvers/ransac.rs`, unblocking the wasm32 targets in `duckdb/extension-ci-tools` (which use Rust 1.86) — sipemu/anofox-regression#20.

## Verified
- \`cargo test --release --workspace\` — 144/144 tests pass.
- No breaking signature changes on the estimators currently wrapped (OLS, Ridge, ElasticNet, WLS, RLS, Poisson, ALM, BLS/NNLS, PLS, Isotonic, Quantile).
- Build succeeds clean.

Shipped as its own PR so any platform-specific upgrade fallout can be reverted independently of the new-estimator wiring work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)