### PR TITLE
Add Huber FFI surface (layer 2 of #60)

### DIFF
--- a/crates/anofox-stats-ffi/src/lib.rs
+++ b/crates/anofox-stats-ffi/src/lib.rs
@@ -10,11 +10,11 @@ use anofox_stats_core::{
     diagnostics::{compute_aic, compute_bic, compute_residuals, compute_vif, jarque_bera},
     models::{
         compute_aid, compute_aid_anomalies, fit_alm, fit_binomial, fit_bls, fit_elasticnet,
-        fit_isotonic, fit_lm_dynamic, fit_negbinomial, fit_ols, fit_pls, fit_poisson, fit_quantile,
-        fit_ridge, fit_rls, fit_tweedie, fit_wls, predict, RlsOptions,
+        fit_huber, fit_isotonic, fit_lm_dynamic, fit_negbinomial, fit_ols, fit_pls, fit_poisson,
+        fit_quantile, fit_ridge, fit_rls, fit_tweedie, fit_wls, predict, RlsOptions,
     },
     AidOptions, AlmDistribution, AlmLoss, AlmOptions, BinomialLink, BinomialOptions, BlsOptions,
-    ElasticNetOptions, HcType, InformationCriterion, IsotonicOptions, LambdaScaling,
+    ElasticNetOptions, HcType, HuberOptions, InformationCriterion, IsotonicOptions, LambdaScaling,
     LmDynamicOptions, NegBinomialOptions, OlsOptions, OutlierMethod, PlsOptions, PoissonLink,
     PoissonOptions, QuantileOptions, RidgeOptions, SolverType, StatsError, TweedieOptions,
     WlsOptions,
@@ -303,6 +303,238 @@ pub unsafe extern "C" fn anofox_free_result_inference(result: *mut FitResultInfe
     if !(*result).ci_upper.is_null() {
         libc::free((*result).ci_upper as *mut libc::c_void);
         (*result).ci_upper = std::ptr::null_mut();
+    }
+}
+
+/// Fit a Huber M-estimator robust regression model.
+///
+/// # Safety
+/// - `y` must be a valid DataArray
+/// - `x` must point to `x_count` valid DataArray structs
+/// - `out_core` must be a valid pointer
+/// - `out_inference` can be NULL if inference is not needed
+/// - `out_extras` can be NULL if scale / outlier mask are not needed
+/// - `out_error` must be a valid pointer
+///
+/// Memory rules:
+/// - On success, the caller frees `out_core` via `anofox_free_result_core`,
+///   `out_inference` via `anofox_free_result_inference`, and `out_extras` via
+///   `anofox_free_huber_extras`.
+/// - On failure, no allocations are returned (the function frees any partial
+///   allocations before returning false).
+///
+/// # Returns
+/// `true` on success, `false` on error (check `out_error` for details).
+#[no_mangle]
+pub unsafe extern "C" fn anofox_huber_fit(
+    y: DataArray,
+    x: *const DataArray,
+    x_count: usize,
+    options: HuberOptionsFFI,
+    out_core: *mut FitResultCore,
+    out_inference: *mut FitResultInference,
+    out_extras: *mut HuberFitExtras,
+    out_error: *mut AnofoxError,
+) -> bool {
+    if !out_error.is_null() {
+        *out_error = AnofoxError::success();
+    }
+
+    if out_core.is_null() {
+        if !out_error.is_null() {
+            (*out_error).set(ErrorCode::InvalidInput, "out_core is NULL");
+        }
+        return false;
+    }
+
+    if x.is_null() || x_count == 0 {
+        if !out_error.is_null() {
+            (*out_error).set(ErrorCode::InvalidInput, "x is NULL or empty");
+        }
+        return false;
+    }
+
+    let y_vec = y.to_vec();
+    let x_arrays = slice::from_raw_parts(x, x_count);
+    let x_vecs: Vec<Vec<f64>> = x_arrays.iter().map(|arr| arr.to_vec()).collect();
+
+    let opts = HuberOptions {
+        epsilon: options.epsilon,
+        alpha: options.alpha,
+        fit_intercept: options.fit_intercept,
+        max_iterations: options.max_iterations,
+        tolerance: options.tolerance,
+        compute_inference: options.compute_inference,
+        confidence_level: options.confidence_level,
+    };
+
+    let fit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        fit_huber(&y_vec, &x_vecs, &opts)
+    }));
+
+    let fit_result = match fit_result {
+        Ok(r) => r,
+        Err(_) => {
+            if !out_error.is_null() {
+                (*out_error).set(ErrorCode::InternalError, "Internal panic in Huber fit");
+            }
+            return false;
+        }
+    };
+
+    match fit_result {
+        Ok(huber) => {
+            let result = huber.fit;
+            let n_coef = result.core.coefficients.len();
+
+            let coef_ptr = libc::malloc(n_coef * std::mem::size_of::<f64>()) as *mut f64;
+            if coef_ptr.is_null() && n_coef > 0 {
+                if !out_error.is_null() {
+                    (*out_error).set(
+                        ErrorCode::AllocationFailure,
+                        "Failed to allocate coefficients",
+                    );
+                }
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(result.core.coefficients.as_ptr(), coef_ptr, n_coef);
+
+            (*out_core) = FitResultCore {
+                coefficients: coef_ptr,
+                coefficients_len: n_coef,
+                intercept: result.core.intercept.unwrap_or(f64::NAN),
+                r_squared: result.core.r_squared,
+                adj_r_squared: result.core.adj_r_squared,
+                residual_std_error: result.core.residual_std_error,
+                n_observations: result.core.n_observations,
+                n_features: result.core.n_features,
+            };
+
+            if !out_inference.is_null() {
+                if let Some(inf) = result.inference {
+                    let n = inf.std_errors.len();
+
+                    let std_err_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let t_val_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let p_val_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let ci_lo_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let ci_hi_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+
+                    if n > 0
+                        && (std_err_ptr.is_null()
+                            || t_val_ptr.is_null()
+                            || p_val_ptr.is_null()
+                            || ci_lo_ptr.is_null()
+                            || ci_hi_ptr.is_null())
+                    {
+                        if !std_err_ptr.is_null() {
+                            libc::free(std_err_ptr as *mut libc::c_void);
+                        }
+                        if !t_val_ptr.is_null() {
+                            libc::free(t_val_ptr as *mut libc::c_void);
+                        }
+                        if !p_val_ptr.is_null() {
+                            libc::free(p_val_ptr as *mut libc::c_void);
+                        }
+                        if !ci_lo_ptr.is_null() {
+                            libc::free(ci_lo_ptr as *mut libc::c_void);
+                        }
+                        if !ci_hi_ptr.is_null() {
+                            libc::free(ci_hi_ptr as *mut libc::c_void);
+                        }
+                        libc::free(coef_ptr as *mut libc::c_void);
+
+                        if !out_error.is_null() {
+                            (*out_error).set(
+                                ErrorCode::AllocationFailure,
+                                "Failed to allocate inference arrays",
+                            );
+                        }
+                        return false;
+                    }
+
+                    std::ptr::copy_nonoverlapping(inf.std_errors.as_ptr(), std_err_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.t_values.as_ptr(), t_val_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.p_values.as_ptr(), p_val_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.ci_lower.as_ptr(), ci_lo_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.ci_upper.as_ptr(), ci_hi_ptr, n);
+
+                    (*out_inference) = FitResultInference {
+                        std_errors: std_err_ptr,
+                        t_values: t_val_ptr,
+                        p_values: p_val_ptr,
+                        ci_lower: ci_lo_ptr,
+                        ci_upper: ci_hi_ptr,
+                        len: n,
+                        confidence_level: inf.confidence_level,
+                        f_statistic: inf.f_statistic.unwrap_or(f64::NAN),
+                        f_pvalue: inf.f_pvalue.unwrap_or(f64::NAN),
+                    };
+                } else {
+                    (*out_inference) = FitResultInference::default();
+                }
+            }
+
+            if !out_extras.is_null() {
+                let n_out = huber.outliers.len();
+                let outliers_ptr = if n_out > 0 {
+                    let p = libc::malloc(n_out) as *mut u8;
+                    if p.is_null() {
+                        libc::free(coef_ptr as *mut libc::c_void);
+                        if !out_inference.is_null() {
+                            anofox_free_result_inference(out_inference);
+                        }
+                        if !out_error.is_null() {
+                            (*out_error).set(
+                                ErrorCode::AllocationFailure,
+                                "Failed to allocate Huber outlier mask",
+                            );
+                        }
+                        return false;
+                    }
+                    for (i, &flag) in huber.outliers.iter().enumerate() {
+                        *p.add(i) = u8::from(flag);
+                    }
+                    p
+                } else {
+                    std::ptr::null_mut()
+                };
+
+                (*out_extras) = HuberFitExtras {
+                    scale: huber.scale,
+                    epsilon: huber.epsilon,
+                    outliers: outliers_ptr,
+                    outliers_len: n_out,
+                    n_outliers: huber.n_outliers,
+                };
+            }
+
+            true
+        }
+        Err(e) => {
+            if !out_error.is_null() {
+                (*out_error).set(error_to_code(&e), &e.to_string());
+            }
+            false
+        }
+    }
+}
+
+/// Free the outliers array inside a HuberFitExtras previously filled by
+/// anofox_huber_fit.
+///
+/// # Safety
+/// `extras` must be a pointer to a HuberFitExtras previously filled by
+/// anofox_huber_fit, or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn anofox_free_huber_extras(extras: *mut HuberFitExtras) {
+    if extras.is_null() {
+        return;
+    }
+    if !(*extras).outliers.is_null() {
+        libc::free((*extras).outliers as *mut libc::c_void);
+        (*extras).outliers = std::ptr::null_mut();
+        (*extras).outliers_len = 0;
     }
 }
 

--- a/crates/anofox-stats-ffi/src/types.rs
+++ b/crates/anofox-stats-ffi/src/types.rs
@@ -232,6 +232,69 @@ impl Default for OlsOptionsFFI {
     }
 }
 
+/// Huber M-estimator robust regression options for FFI
+#[repr(C)]
+pub struct HuberOptionsFFI {
+    /// Huber threshold parameter (must be > 1.0). Default 1.35.
+    pub epsilon: f64,
+    /// L2 regularization (must be >= 0). Default 0.0001.
+    pub alpha: f64,
+    /// Whether to fit intercept.
+    pub fit_intercept: bool,
+    /// Whether to compute inference statistics.
+    pub compute_inference: bool,
+    /// Confidence level for CIs.
+    pub confidence_level: f64,
+    /// Maximum IRLS iterations.
+    pub max_iterations: u32,
+    /// Convergence tolerance.
+    pub tolerance: f64,
+}
+
+impl Default for HuberOptionsFFI {
+    fn default() -> Self {
+        Self {
+            epsilon: 1.35,
+            alpha: 0.0001,
+            fit_intercept: true,
+            compute_inference: false,
+            confidence_level: 0.95,
+            max_iterations: 100,
+            tolerance: 1e-5,
+        }
+    }
+}
+
+/// Huber-specific diagnostics returned alongside FitResultCore / FitResultInference.
+/// Memory rules: `outliers` is allocated by `anofox_huber_fit` and must be freed
+/// via `anofox_free_huber_extras` (boolean array exposed as u8: 0 = inlier, 1 = outlier).
+#[repr(C)]
+pub struct HuberFitExtras {
+    /// MAD-based scale estimate (sigma).
+    pub scale: f64,
+    /// Echoed epsilon used for the fit.
+    pub epsilon: f64,
+    /// Per-observation outlier mask (1 = |r_i| > epsilon * scale).
+    pub outliers: *mut u8,
+    /// Number of valid (non-NaN) observations the fit was computed on
+    /// — equals `outliers` array length.
+    pub outliers_len: usize,
+    /// Number of observations flagged as outliers.
+    pub n_outliers: usize,
+}
+
+impl Default for HuberFitExtras {
+    fn default() -> Self {
+        Self {
+            scale: f64::NAN,
+            epsilon: f64::NAN,
+            outliers: std::ptr::null_mut(),
+            outliers_len: 0,
+            n_outliers: 0,
+        }
+    }
+}
+
 /// Ridge regression options for FFI
 #[repr(C)]
 pub struct RidgeOptionsFFI {

--- a/src/include/anofox_stats_ffi.h
+++ b/src/include/anofox_stats_ffi.h
@@ -166,6 +166,72 @@ void anofox_free_result_core(AnofoxFitResultCore *result);
 void anofox_free_result_inference(AnofoxFitResultInference *result);
 
 /**
+ * Huber M-estimator robust regression options for FFI
+ */
+typedef struct {
+    /** Huber threshold parameter (must be > 1.0). Default 1.35. */
+    double epsilon;
+    /** L2 regularization (must be >= 0). Default 0.0001. */
+    double alpha;
+    /** Whether to fit intercept */
+    bool fit_intercept;
+    /** Whether to compute inference statistics */
+    bool compute_inference;
+    /** Confidence level for CIs */
+    double confidence_level;
+    /** Maximum IRLS iterations */
+    uint32_t max_iterations;
+    /** Convergence tolerance */
+    double tolerance;
+} AnofoxHuberOptions;
+
+/**
+ * Huber-specific extras returned alongside core/inference results.
+ *
+ * Memory: `outliers` is allocated by anofox_huber_fit when out_extras != NULL
+ * and must be freed via anofox_free_huber_extras. Each byte is 0 (inlier) or
+ * 1 (outlier). Length equals the number of non-NaN observations used in the
+ * fit (which can be less than the input length when NaNs were filtered out).
+ */
+typedef struct {
+    /** MAD-based scale estimate (sigma) */
+    double scale;
+    /** Echoed epsilon used for the fit */
+    double epsilon;
+    /** Per-observation outlier mask: 1 = |r_i| > epsilon * scale */
+    uint8_t *outliers;
+    /** Length of the outliers array */
+    size_t outliers_len;
+    /** Number of observations flagged as outliers */
+    size_t n_outliers;
+} AnofoxHuberFitExtras;
+
+/**
+ * Fit a Huber M-estimator robust regression model.
+ *
+ * @param y Response variable array
+ * @param x Pointer to array of feature arrays
+ * @param x_count Number of feature arrays
+ * @param options Huber fitting options
+ * @param out_core Output: core fit results (required)
+ * @param out_inference Output: inference results (NULL if not needed)
+ * @param out_extras Output: Huber-specific scale + outlier mask (NULL if not needed)
+ * @param out_error Output: error information (required)
+ * @return true on success, false on error
+ */
+bool anofox_huber_fit(AnofoxDataArray y, const AnofoxDataArray *x, size_t x_count,
+                      AnofoxHuberOptions options, AnofoxFitResultCore *out_core,
+                      AnofoxFitResultInference *out_inference, AnofoxHuberFitExtras *out_extras,
+                      AnofoxError *out_error);
+
+/**
+ * Free the outliers array inside a AnofoxHuberFitExtras previously filled by
+ * anofox_huber_fit. The core / inference parts are freed via the standard
+ * anofox_free_result_core / anofox_free_result_inference helpers.
+ */
+void anofox_free_huber_extras(AnofoxHuberFitExtras *extras);
+
+/**
  * Ridge regression options for FFI
  */
 typedef struct {


### PR DESCRIPTION
Second layer of #60. Re-opened against \`main\` after #67 (Rust core) merged and the previous PR auto-closed.

## What this delivers
- \`AnofoxHuberOptions\` FFI struct.
- \`AnofoxHuberFitExtras\` — Huber-specific extras (scale, echoed epsilon, outlier mask, outlier count).
- \`anofox_huber_fit\` extern "C" function with the same panic-safe + rollback-on-failure contract as the OLS FFI.
- \`anofox_free_huber_extras\` helper; core/inference reuse the existing free helpers.
- Hand-maintained C declarations in \`src/include/anofox_stats_ffi.h\`.

## Verified
- \`cargo build --release\` clean.
- \`cargo test --release --workspace\` — 148/148 (4 Huber tests + 144 pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)