### PR TITLE
Add Huber fit_predict aggregate (layer 4a of #60)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(EXTENSION_SOURCES
     src/aggregate_functions/jarque_bera_aggregate.cpp
     src/aggregate_functions/residuals_diagnostics_aggregate.cpp
     src/aggregate_functions/ols_predict_aggregate.cpp
+    src/aggregate_functions/huber_predict_aggregate.cpp
     src/aggregate_functions/ridge_predict_aggregate.cpp
     src/aggregate_functions/wls_predict_aggregate.cpp
     src/aggregate_functions/rls_predict_aggregate.cpp

--- a/src/aggregate_functions/huber_predict_aggregate.cpp
+++ b/src/aggregate_functions/huber_predict_aggregate.cpp
@@ -1,0 +1,553 @@
+#include <cmath>
+#include <vector>
+
+#include "duckdb.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
+
+#include "../include/anofox_stats_ffi.h"
+#include "../include/ffi_enum_converters.hpp"
+#include "../include/map_options_parser.hpp"
+#include "telemetry.hpp"
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Huber predict aggregate state — accumulates training rows for the fit AND
+// every input row for the prediction loop. Mirrors OlsPredictAggState.
+//===--------------------------------------------------------------------===//
+struct HuberPredictAggState {
+    // Training data (rows where y is NOT NULL or split column says "train")
+    vector<double> y_train;
+    vector<vector<double>> x_train;
+
+    // All rows, for the per-row prediction emission
+    vector<double> y_all;
+    vector<bool> y_is_null;
+    vector<bool> is_training;
+    vector<vector<double>> x_all;
+
+    idx_t n_features;
+    bool initialized;
+
+    // Options
+    bool fit_intercept;
+    double confidence_level;
+    double epsilon;
+    double alpha;
+    uint32_t max_iterations;
+    double tolerance;
+    NullPolicy null_policy;
+    bool use_split_col;
+
+    HuberPredictAggState()
+        : n_features(0), initialized(false), fit_intercept(true), confidence_level(0.95), epsilon(1.35),
+          alpha(0.0001), max_iterations(100), tolerance(1e-5), null_policy(NullPolicy::DROP), use_split_col(false) {}
+
+    void Reset() {
+        y_train.clear();
+        x_train.clear();
+        y_all.clear();
+        y_is_null.clear();
+        is_training.clear();
+        x_all.clear();
+        n_features = 0;
+        initialized = false;
+    }
+};
+
+//===--------------------------------------------------------------------===//
+// Bind data — cached options parsed once from the optional MAP argument.
+//===--------------------------------------------------------------------===//
+struct HuberPredictAggBindData : public FunctionData {
+    bool fit_intercept = true;
+    double confidence_level = 0.95;
+    double epsilon = 1.35;
+    double alpha = 0.0001;
+    uint32_t max_iterations = 100;
+    double tolerance = 1e-5;
+    NullPolicy null_policy = NullPolicy::DROP;
+    bool use_split_col = false;
+
+    unique_ptr<FunctionData> Copy() const override {
+        auto result = make_uniq<HuberPredictAggBindData>();
+        result->fit_intercept = fit_intercept;
+        result->confidence_level = confidence_level;
+        result->epsilon = epsilon;
+        result->alpha = alpha;
+        result->max_iterations = max_iterations;
+        result->tolerance = tolerance;
+        result->null_policy = null_policy;
+        result->use_split_col = use_split_col;
+        return std::move(result);
+    }
+
+    bool Equals(const FunctionData &other_p) const override {
+        auto &other = other_p.Cast<HuberPredictAggBindData>();
+        return fit_intercept == other.fit_intercept && confidence_level == other.confidence_level &&
+               epsilon == other.epsilon && alpha == other.alpha && max_iterations == other.max_iterations &&
+               tolerance == other.tolerance && null_policy == other.null_policy &&
+               use_split_col == other.use_split_col;
+    }
+};
+
+//===--------------------------------------------------------------------===//
+// Result type: LIST(STRUCT(y, yhat, yhat_lower, yhat_upper, is_training))
+//
+// Note: the Huber-specific MAD scale and outlier count are not surfaced here
+// — that's a per-fit concept and lives in huber_fit_agg's result. Keeping the
+// shape identical to ols_fit_predict_agg means the existing
+// `*_fit_predict_by` macros and downstream UNNEST patterns work unchanged.
+//===--------------------------------------------------------------------===//
+static LogicalType GetHuberPredictAggResultType() {
+    child_list_t<LogicalType> row_children;
+    row_children.push_back(make_pair("y", LogicalType::DOUBLE));
+    row_children.push_back(make_pair("yhat", LogicalType::DOUBLE));
+    row_children.push_back(make_pair("yhat_lower", LogicalType::DOUBLE));
+    row_children.push_back(make_pair("yhat_upper", LogicalType::DOUBLE));
+    row_children.push_back(make_pair("is_training", LogicalType::BOOLEAN));
+
+    auto row_struct = LogicalType::STRUCT(std::move(row_children));
+    return LogicalType::LIST(row_struct);
+}
+
+//===--------------------------------------------------------------------===//
+// State machine
+//===--------------------------------------------------------------------===//
+
+static void HuberPredictAggInitialize(const AggregateFunction &, data_ptr_t state_p) {
+    new (state_p) HuberPredictAggState();
+}
+
+static void HuberPredictAggDestroy(Vector &state_vector, AggregateInputData &, idx_t count) {
+    UnifiedVectorFormat sdata;
+    state_vector.ToUnifiedFormat(count, sdata);
+    auto states = (HuberPredictAggState **)sdata.data;
+
+    for (idx_t i = 0; i < count; i++) {
+        auto &state = *states[sdata.sel->get_index(i)];
+        state.~HuberPredictAggState();
+    }
+}
+
+// Helper: check if a split-column value is the training marker (case-insensitive).
+static bool IsSplitTraining(const string_t &split_val) {
+    string val = split_val.GetString();
+    for (auto &c : val) {
+        c = std::tolower(c);
+    }
+    return val == "train" || val == "training";
+}
+
+static void HuberPredictAggUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count,
+                                  Vector &state_vector, idx_t count) {
+    auto &bind_data = aggr_input_data.bind_data->Cast<HuberPredictAggBindData>();
+
+    UnifiedVectorFormat y_data;
+    UnifiedVectorFormat x_data;
+    inputs[0].ToUnifiedFormat(count, y_data);
+    inputs[1].ToUnifiedFormat(count, x_data);
+
+    auto y_values = UnifiedVectorFormat::GetData<double>(y_data);
+    auto x_list_data = ListVector::GetData(inputs[1]);
+    auto &x_child = ListVector::GetEntry(inputs[1]);
+    auto x_child_data = FlatVector::GetData<double>(x_child);
+
+    UnifiedVectorFormat split_data;
+    const string_t *split_values = nullptr;
+    if (bind_data.use_split_col && input_count >= 3) {
+        inputs[2].ToUnifiedFormat(count, split_data);
+        split_values = UnifiedVectorFormat::GetData<string_t>(split_data);
+    }
+
+    UnifiedVectorFormat sdata;
+    state_vector.ToUnifiedFormat(count, sdata);
+    auto states = (HuberPredictAggState **)sdata.data;
+
+    for (idx_t i = 0; i < count; i++) {
+        auto &state = *states[sdata.sel->get_index(i)];
+
+        state.fit_intercept = bind_data.fit_intercept;
+        state.confidence_level = bind_data.confidence_level;
+        state.epsilon = bind_data.epsilon;
+        state.alpha = bind_data.alpha;
+        state.max_iterations = bind_data.max_iterations;
+        state.tolerance = bind_data.tolerance;
+        state.null_policy = bind_data.null_policy;
+        state.use_split_col = bind_data.use_split_col;
+
+        auto x_idx = x_data.sel->get_index(i);
+        if (!x_data.validity.RowIsValid(x_idx)) {
+            continue;
+        }
+
+        auto list_entry = x_list_data[x_idx];
+        idx_t n_features = list_entry.length;
+
+        if (!state.initialized) {
+            state.n_features = n_features;
+            state.x_train.resize(n_features);
+            state.initialized = true;
+        }
+
+        if (n_features != state.n_features) {
+            throw InvalidInputException("Inconsistent feature count: expected %lu, got %lu", state.n_features,
+                                        n_features);
+        }
+
+        vector<double> x_row(n_features);
+        for (idx_t j = 0; j < n_features; j++) {
+            x_row[j] = x_child_data[list_entry.offset + j];
+        }
+
+        auto y_idx = y_data.sel->get_index(i);
+        bool y_valid = y_data.validity.RowIsValid(y_idx);
+        double y_val = y_valid ? y_values[y_idx] : std::nan("");
+
+        bool row_is_training;
+        if (bind_data.use_split_col && split_values) {
+            auto split_idx = split_data.sel->get_index(i);
+            if (split_data.validity.RowIsValid(split_idx)) {
+                row_is_training = IsSplitTraining(split_values[split_idx]);
+            } else {
+                row_is_training = false;
+            }
+            if (row_is_training && !y_valid) {
+                row_is_training = false;
+            }
+        } else {
+            row_is_training = y_valid;
+        }
+
+        if (row_is_training && state.null_policy == NullPolicy::DROP_Y_ZERO_X) {
+            for (idx_t j = 0; j < n_features; j++) {
+                if (x_row[j] == 0.0) {
+                    row_is_training = false;
+                    break;
+                }
+            }
+        }
+
+        state.y_all.push_back(y_val);
+        state.y_is_null.push_back(!y_valid);
+        state.is_training.push_back(row_is_training);
+        state.x_all.push_back(x_row);
+
+        if (row_is_training) {
+            state.y_train.push_back(y_val);
+            for (idx_t j = 0; j < n_features; j++) {
+                state.x_train[j].push_back(x_row[j]);
+            }
+        }
+    }
+}
+
+static void HuberPredictAggCombine(Vector &source_vector, Vector &target_vector, AggregateInputData &, idx_t count) {
+    UnifiedVectorFormat source_data, target_data;
+    source_vector.ToUnifiedFormat(count, source_data);
+    target_vector.ToUnifiedFormat(count, target_data);
+
+    auto sources = (HuberPredictAggState **)source_data.data;
+    auto targets = (HuberPredictAggState **)target_data.data;
+
+    for (idx_t i = 0; i < count; i++) {
+        auto &source = *sources[source_data.sel->get_index(i)];
+        auto &target = *targets[target_data.sel->get_index(i)];
+
+        if (!source.initialized) {
+            continue;
+        }
+
+        if (!target.initialized) {
+            target.y_train = std::move(source.y_train);
+            target.x_train = std::move(source.x_train);
+            target.y_all = std::move(source.y_all);
+            target.y_is_null = std::move(source.y_is_null);
+            target.is_training = std::move(source.is_training);
+            target.x_all = std::move(source.x_all);
+            target.n_features = source.n_features;
+            target.initialized = true;
+            target.fit_intercept = source.fit_intercept;
+            target.confidence_level = source.confidence_level;
+            target.epsilon = source.epsilon;
+            target.alpha = source.alpha;
+            target.max_iterations = source.max_iterations;
+            target.tolerance = source.tolerance;
+            target.null_policy = source.null_policy;
+            target.use_split_col = source.use_split_col;
+            continue;
+        }
+
+        if (source.n_features != target.n_features) {
+            throw InvalidInputException("Cannot combine states with different feature counts: %lu vs %lu",
+                                        source.n_features, target.n_features);
+        }
+
+        target.y_train.insert(target.y_train.end(), source.y_train.begin(), source.y_train.end());
+        for (idx_t j = 0; j < target.n_features; j++) {
+            target.x_train[j].insert(target.x_train[j].end(), source.x_train[j].begin(), source.x_train[j].end());
+        }
+
+        target.y_all.insert(target.y_all.end(), source.y_all.begin(), source.y_all.end());
+        target.y_is_null.insert(target.y_is_null.end(), source.y_is_null.begin(), source.y_is_null.end());
+        target.is_training.insert(target.is_training.end(), source.is_training.begin(), source.is_training.end());
+        target.x_all.insert(target.x_all.end(), source.x_all.begin(), source.x_all.end());
+    }
+}
+
+static void HuberPredictAggFinalize(Vector &state_vector, AggregateInputData &aggr_input_data, Vector &result,
+                                    idx_t count, idx_t offset) {
+    UnifiedVectorFormat sdata;
+    state_vector.ToUnifiedFormat(count, sdata);
+    auto states = (HuberPredictAggState **)sdata.data;
+
+    for (idx_t i = 0; i < count; i++) {
+        auto &state = *states[sdata.sel->get_index(i)];
+        idx_t result_idx = i + offset;
+
+        if (!state.initialized || state.y_train.size() < 2) {
+            FlatVector::SetNull(result, result_idx, true);
+            continue;
+        }
+
+        AnofoxDataArray y_array;
+        y_array.data = state.y_train.data();
+        y_array.validity = nullptr;
+        y_array.len = state.y_train.size();
+
+        vector<AnofoxDataArray> x_arrays;
+        for (auto &col : state.x_train) {
+            AnofoxDataArray arr;
+            arr.data = col.data();
+            arr.validity = nullptr;
+            arr.len = col.size();
+            x_arrays.push_back(arr);
+        }
+
+        AnofoxHuberOptions options;
+        options.epsilon = state.epsilon;
+        options.alpha = state.alpha;
+        options.fit_intercept = state.fit_intercept;
+        options.compute_inference = false;
+        options.confidence_level = state.confidence_level;
+        options.max_iterations = state.max_iterations;
+        options.tolerance = state.tolerance;
+
+        AnofoxFitResultCore core_result;
+        AnofoxError error;
+
+        // Predict-only flow: no inference, no extras — the per-row predictions
+        // are the value-add here, not the Huber-specific scale / outlier
+        // diagnostics (those are surfaced by huber_fit_agg).
+        bool success = anofox_huber_fit(y_array, x_arrays.data(), x_arrays.size(), options, &core_result,
+                                        nullptr, nullptr, &error);
+
+        if (!success) {
+            FlatVector::SetNull(result, result_idx, true);
+            continue;
+        }
+
+        idx_t n_rows = state.y_all.size();
+        auto *list_data = ListVector::GetData(result);
+        auto list_offset = ListVector::GetListSize(result);
+
+        list_data[result_idx].offset = list_offset;
+        list_data[result_idx].length = n_rows;
+
+        ListVector::Reserve(result, list_offset + n_rows);
+        ListVector::SetListSize(result, list_offset + n_rows);
+
+        auto &child_struct = ListVector::GetEntry(result);
+        auto &struct_entries = StructVector::GetEntries(child_struct);
+
+        auto &y_vec = *struct_entries[0];
+        auto &yhat_vec = *struct_entries[1];
+        auto &yhat_lower_vec = *struct_entries[2];
+        auto &yhat_upper_vec = *struct_entries[3];
+        auto &is_training_vec = *struct_entries[4];
+
+        for (idx_t row = 0; row < n_rows; row++) {
+            idx_t child_idx = list_offset + row;
+
+            if (state.y_is_null[row]) {
+                FlatVector::SetNull(y_vec, child_idx, true);
+            } else {
+                FlatVector::GetData<double>(y_vec)[child_idx] = state.y_all[row];
+            }
+
+            AnofoxPredictionResult pred;
+            bool pred_success = anofox_predict_with_interval(
+                core_result.coefficients, core_result.coefficients_len, core_result.intercept,
+                state.x_all[row].data(), state.n_features, core_result.residual_std_error,
+                core_result.n_observations, state.confidence_level, &pred);
+
+            if (pred_success) {
+                FlatVector::GetData<double>(yhat_vec)[child_idx] = pred.yhat;
+                FlatVector::GetData<double>(yhat_lower_vec)[child_idx] = pred.yhat_lower;
+                FlatVector::GetData<double>(yhat_upper_vec)[child_idx] = pred.yhat_upper;
+            } else {
+                FlatVector::SetNull(yhat_vec, child_idx, true);
+                FlatVector::SetNull(yhat_lower_vec, child_idx, true);
+                FlatVector::SetNull(yhat_upper_vec, child_idx, true);
+            }
+
+            FlatVector::GetData<bool>(is_training_vec)[child_idx] = state.is_training[row];
+        }
+
+        anofox_free_result_core(&core_result);
+        state.Reset();
+    }
+}
+
+//===--------------------------------------------------------------------===//
+// Bind functions
+//===--------------------------------------------------------------------===//
+
+// Shared option-extraction helper used by both bind variants. RegressionMapOptions
+// already covers every Huber knob (epsilon was added in #69; alpha/max_iterations/
+// tolerance/fit_intercept/confidence_level were pre-existing).
+static void ExtractHuberOptions(ClientContext &context, Expression &opts_expr, HuberPredictAggBindData &result) {
+    auto opts = RegressionMapOptions::ParseFromExpression(context, opts_expr);
+    if (opts.fit_intercept.has_value()) {
+        result.fit_intercept = opts.fit_intercept.value();
+    }
+    if (opts.confidence_level.has_value()) {
+        result.confidence_level = opts.confidence_level.value();
+    }
+    if (opts.epsilon.has_value()) {
+        result.epsilon = opts.epsilon.value();
+    }
+    if (opts.alpha.has_value()) {
+        result.alpha = opts.alpha.value();
+    }
+    if (opts.max_iterations.has_value()) {
+        result.max_iterations = opts.max_iterations.value();
+    }
+    if (opts.tolerance.has_value()) {
+        result.tolerance = opts.tolerance.value();
+    }
+    if (opts.null_policy.has_value()) {
+        result.null_policy = opts.null_policy.value();
+    }
+}
+
+static unique_ptr<FunctionData> HuberPredictAggBind(ClientContext &context, AggregateFunction &function,
+                                                    vector<unique_ptr<Expression>> &arguments) {
+    auto result = make_uniq<HuberPredictAggBindData>();
+
+    if (arguments.size() >= 3 && arguments[2]->IsFoldable()) {
+        ExtractHuberOptions(context, *arguments[2], *result);
+    }
+
+    function.return_type = GetHuberPredictAggResultType();
+    PostHogTelemetry::Instance().CaptureFunctionExecution("huber_fit_predict_agg");
+    return std::move(result);
+}
+
+static unique_ptr<FunctionData> HuberPredictAggBindWithSplit(ClientContext &context, AggregateFunction &function,
+                                                              vector<unique_ptr<Expression>> &arguments) {
+    auto result = make_uniq<HuberPredictAggBindData>();
+    result->use_split_col = true;
+
+    if (arguments.size() >= 4 && arguments[3]->IsFoldable()) {
+        ExtractHuberOptions(context, *arguments[3], *result);
+    }
+
+    function.return_type = GetHuberPredictAggResultType();
+    PostHogTelemetry::Instance().CaptureFunctionExecution("huber_fit_predict_agg");
+    return std::move(result);
+}
+
+//===--------------------------------------------------------------------===//
+// Registration
+//===--------------------------------------------------------------------===//
+void RegisterHuberFitPredictAggregateFunction(ExtensionLoader &loader) {
+    AggregateFunctionSet func_set("anofox_stats_huber_fit_predict_agg");
+
+    auto basic_func = AggregateFunction(
+        "anofox_stats_huber_fit_predict_agg", {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)},
+        LogicalType::ANY, AggregateFunction::StateSize<HuberPredictAggState>, HuberPredictAggInitialize,
+        HuberPredictAggUpdate, HuberPredictAggCombine, HuberPredictAggFinalize, nullptr, HuberPredictAggBind,
+        HuberPredictAggDestroy);
+    func_set.AddFunction(basic_func);
+
+    auto map_func = AggregateFunction(
+        "anofox_stats_huber_fit_predict_agg",
+        {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY}, LogicalType::ANY,
+        AggregateFunction::StateSize<HuberPredictAggState>, HuberPredictAggInitialize, HuberPredictAggUpdate,
+        HuberPredictAggCombine, HuberPredictAggFinalize, nullptr, HuberPredictAggBind, HuberPredictAggDestroy);
+    func_set.AddFunction(map_func);
+
+    auto split_func = AggregateFunction(
+        "anofox_stats_huber_fit_predict_agg",
+        {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR}, LogicalType::ANY,
+        AggregateFunction::StateSize<HuberPredictAggState>, HuberPredictAggInitialize, HuberPredictAggUpdate,
+        HuberPredictAggCombine, HuberPredictAggFinalize, nullptr, HuberPredictAggBindWithSplit,
+        HuberPredictAggDestroy);
+    func_set.AddFunction(split_func);
+
+    auto split_opts_func = AggregateFunction(
+        "anofox_stats_huber_fit_predict_agg",
+        {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR, LogicalType::ANY},
+        LogicalType::ANY, AggregateFunction::StateSize<HuberPredictAggState>, HuberPredictAggInitialize,
+        HuberPredictAggUpdate, HuberPredictAggCombine, HuberPredictAggFinalize, nullptr,
+        HuberPredictAggBindWithSplit, HuberPredictAggDestroy);
+    func_set.AddFunction(split_opts_func);
+
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+    FunctionDescription d1;
+    d1.description =
+        "Fits a Huber M-estimator robust regression over a partition and returns per-row predictions with "
+        "confidence intervals.";
+    d1.examples = {"anofox_stats_huber_fit_predict_agg(y, x)"};
+    d1.categories = {"regression", "prediction"};
+    d1.parameter_names = {"y", "x"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d1));
+
+    FunctionDescription d2;
+    d2.description = "Fits Huber regression over a partition with a MAP of options and returns per-row "
+                     "predictions with confidence intervals.";
+    d2.examples = {"anofox_stats_huber_fit_predict_agg(y, x, {'epsilon': 1.35, 'null_policy': 'drop'})"};
+    d2.categories = {"regression", "prediction"};
+    d2.parameter_names = {"y", "x", "options"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d2));
+
+    FunctionDescription d3;
+    d3.description = "Fits Huber regression using only training rows (split_col='train') and predicts all rows.";
+    d3.examples = {"anofox_stats_huber_fit_predict_agg(y, x, split_col)"};
+    d3.categories = {"regression", "prediction"};
+    d3.parameter_names = {"y", "x", "split_col"};
+    d3.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR};
+    info.descriptions.push_back(std::move(d3));
+
+    FunctionDescription d4;
+    d4.description = "Fits Huber regression on training rows with a MAP of options and predicts all rows.";
+    d4.examples = {"anofox_stats_huber_fit_predict_agg(y, x, split_col, {'epsilon': 1.5})"};
+    d4.categories = {"regression", "prediction"};
+    d4.parameter_names = {"y", "x", "split_col", "options"};
+    d4.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::VARCHAR,
+                          LogicalType::ANY};
+    info.descriptions.push_back(std::move(d4));
+
+    loader.RegisterFunction(std::move(info));
+
+    {
+        AggregateFunctionSet alias_set("huber_fit_predict_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        alias_set.AddFunction(split_func);
+        alias_set.AddFunction(split_opts_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_huber_fit_predict_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
+}
+
+} // namespace duckdb

--- a/src/anofox_statistics_extension.cpp
+++ b/src/anofox_statistics_extension.cpp
@@ -158,6 +158,7 @@ void LoadInternal(ExtensionLoader &loader) {
 
     // Register fit + predict aggregate functions (with deprecated aliases)
     RegisterOlsFitPredictAggregateFunction(loader);
+    RegisterHuberFitPredictAggregateFunction(loader);
     RegisterRidgeFitPredictAggregateFunction(loader);
     RegisterWlsFitPredictAggregateFunction(loader);
     RegisterRlsFitPredictAggregateFunction(loader);

--- a/src/include/anofox_statistics_extension.hpp
+++ b/src/include/anofox_statistics_extension.hpp
@@ -30,6 +30,7 @@ void RegisterElasticNetFitPredictFunction(ExtensionLoader &loader);
 
 // Fit + Predict aggregate functions (fit + predict all rows, with deprecated aliases)
 void RegisterOlsFitPredictAggregateFunction(ExtensionLoader &loader);
+void RegisterHuberFitPredictAggregateFunction(ExtensionLoader &loader);
 void RegisterRidgeFitPredictAggregateFunction(ExtensionLoader &loader);
 void RegisterWlsFitPredictAggregateFunction(ExtensionLoader &loader);
 void RegisterRlsFitPredictAggregateFunction(ExtensionLoader &loader);


### PR DESCRIPTION
Layer 4a of #60. Adds the per-row prediction aggregate, mirroring \`ols_fit_predict_agg\`.

## What this delivers

\`\`\`sql
-- Per-group fit + predict in one aggregate; the LIST is then UNNEST-ed
-- by the existing huber_fit_predict_by macro pattern (follow-up PR).
SELECT
    category,
    UNNEST(huber_fit_predict_agg(sales, [price, qty], {'epsilon': 1.5})) AS row
FROM sales_data
GROUP BY category;
-- row.y, row.yhat, row.yhat_lower, row.yhat_upper, row.is_training

-- With explicit split column
SELECT *
FROM (
    SELECT UNNEST(huber_fit_predict_agg(y, x, split, {'epsilon': 1.35})) AS r
    FROM observations
);
\`\`\`

## Overloads (4 signatures, mirroring OLS)
1. \`huber_fit_predict_agg(y, x)\`
2. \`huber_fit_predict_agg(y, x, options_map)\`
3. \`huber_fit_predict_agg(y, x, split_col)\`
4. \`huber_fit_predict_agg(y, x, split_col, options_map)\`

Primary name: \`anofox_stats_huber_fit_predict_agg\`. Alias: \`huber_fit_predict_agg\`.

## Result shape
\`LIST(STRUCT(y, yhat, yhat_lower, yhat_upper, is_training))\` — **identical** to \`ols_fit_predict_agg\`. The Huber-specific \`scale\` (MAD σ) and \`n_outliers\` are intentionally NOT surfaced here:
- They're per-fit diagnostics, not per-row.
- Keeping the per-row shape identical to OLS preserves drop-in compatibility with the existing \`*_fit_predict_by\` macros and UNNEST-based downstream patterns.

Users who want the Huber-specific diagnostics call \`huber_fit_agg(y, x)\` from #69 alongside the prediction.

## Options
MAP keys: \`epsilon\`, \`alpha\`, \`fit_intercept\`, \`confidence_level\`, \`max_iterations\`, \`tolerance\`, \`null_policy\`. All parsed via the existing \`RegressionMapOptions\`.

## File-level changes
- \`src/aggregate_functions/huber_predict_aggregate.cpp\` (new, ~580 LOC mirroring \`ols_predict_aggregate.cpp\`) — state machine (Init/Destroy/Update/Combine/Finalize), two Bind variants (with/without split column), Finalize calls \`anofox_huber_fit\` then loops with \`anofox_predict_with_interval\` per row.
- \`src/include/anofox_statistics_extension.hpp\` — forward declaration.
- \`src/anofox_statistics_extension.cpp\` — registers alongside \`RegisterOlsFitPredictAggregateFunction\`.
- \`CMakeLists.txt\` — adds the source.

## Verified
- \`cargo build --release\` clean (no Rust changes).
- C++ side validated by CI; not buildable locally without DuckDB submodule init.

## What's left for full #60 closure
- Layer 4b: \`huber_fit_predict\` window function + \`huber_fit_predict_by\` table macro.
- Layer 5: SQL tests + README updates.
- Then layers 1–5 for RANSAC and Theil-Sen (near-mechanical clones of the Huber chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)