### PR TITLE
Add Theil-Sen robust regression Rust wrapper (layer 1 of #60 — Theil-Sen)

### DIFF
--- a/crates/anofox-stats-core/src/models/mod.rs
+++ b/crates/anofox-stats-core/src/models/mod.rs
@@ -16,6 +16,7 @@ mod quantile;
 mod ransac;
 mod ridge;
 mod rls;
+mod theil_sen;
 mod wls;
 
 pub use aid::{compute_aid, compute_aid_anomalies};
@@ -34,4 +35,5 @@ pub use quantile::fit_quantile;
 pub use ransac::{fit_ransac, RansacResult};
 pub use ridge::fit_ridge;
 pub use rls::{fit_rls, RlsOptions, RlsState};
+pub use theil_sen::{fit_theilsen, TheilSenResult};
 pub use wls::fit_wls;

--- a/crates/anofox-stats-core/src/models/theil_sen.rs
+++ b/crates/anofox-stats-core/src/models/theil_sen.rs
@@ -1,0 +1,251 @@
+//! Theil-Sen robust regression wrapper.
+//!
+//! Wraps `anofox_regression::solvers::TheilSenRegressor` and reshapes its
+//! result into the workspace-local `FitResult`. Theil-Sen has no
+//! consensus-set diagnostics to surface (no inlier mask, no trial count) —
+//! the upstream `FittedTheilSen` exposes only the standard `RegressionResult`
+//! and a `with_intercept` flag.
+
+use crate::errors::{StatsError, StatsResult};
+use crate::types::{FitResult, FitResultCore, FitResultInference, TheilSenOptions};
+use anofox_regression::solvers::{FittedRegressor, Regressor, TheilSenRegressor};
+use faer::{Col, Mat};
+
+/// Theil-Sen regression fit. Identical fields to `FitResult` — kept as a
+/// distinct type so the FFI / downstream wrappers can grow estimator-specific
+/// extras later without touching the OLS / Huber / RANSAC contracts.
+#[derive(Debug, Clone)]
+pub struct TheilSenResult {
+    pub fit: FitResult,
+}
+
+/// Fit a Theil-Sen robust regression model.
+pub fn fit_theilsen(
+    y: &[f64],
+    x: &[Vec<f64>],
+    options: &TheilSenOptions,
+) -> StatsResult<TheilSenResult> {
+    if y.is_empty() {
+        return Err(StatsError::EmptyInput { field: "y" });
+    }
+    if x.is_empty() {
+        return Err(StatsError::EmptyInput { field: "x" });
+    }
+    if options.max_subpopulation == 0 {
+        return Err(StatsError::InvalidInput(
+            "max_subpopulation must be > 0".to_string(),
+        ));
+    }
+    if options.max_iterations == 0 {
+        return Err(StatsError::InvalidInput(
+            "max_iterations must be > 0".to_string(),
+        ));
+    }
+    if !(options.tolerance > 0.0 && options.tolerance.is_finite()) {
+        return Err(StatsError::InvalidInput(format!(
+            "tolerance must be finite and positive, got {}",
+            options.tolerance
+        )));
+    }
+
+    let n_obs = y.len();
+    let n_features = x.len();
+
+    for col in x.iter() {
+        if col.len() != n_obs {
+            return Err(StatsError::DimensionMismatch {
+                y_len: n_obs,
+                x_rows: col.len(),
+            });
+        }
+    }
+
+    let valid_indices: Vec<usize> = (0..n_obs)
+        .filter(|&i| {
+            !y[i].is_nan()
+                && !y[i].is_infinite()
+                && x.iter()
+                    .all(|col| !col[i].is_nan() && !col[i].is_infinite())
+        })
+        .collect();
+
+    if valid_indices.is_empty() {
+        return Err(StatsError::NoValidData);
+    }
+
+    let n_valid = valid_indices.len();
+    let p_eff = if options.fit_intercept {
+        n_features + 1
+    } else {
+        n_features
+    };
+    let effective_n_subsamples = options.n_subsamples.unwrap_or(p_eff).max(p_eff);
+    if n_valid < effective_n_subsamples {
+        return Err(StatsError::InsufficientData {
+            rows: n_valid,
+            cols: n_features,
+        });
+    }
+
+    let y_col = Col::from_fn(n_valid, |i| y[valid_indices[i]]);
+    let x_mat = Mat::from_fn(n_valid, n_features, |i, j| x[j][valid_indices[i]]);
+
+    let mut builder = TheilSenRegressor::builder()
+        .with_intercept(options.fit_intercept)
+        .max_subpopulation(options.max_subpopulation as usize)
+        .max_iter(options.max_iterations as usize)
+        .tolerance(options.tolerance)
+        .random_state(options.random_state);
+    if let Some(n) = options.n_subsamples {
+        builder = builder.n_subsamples(n);
+    }
+
+    let fitted = builder
+        .build()
+        .fit(&x_mat, &y_col)
+        .map_err(|e| StatsError::RegressError(format!("{:?}", e)))?;
+
+    let result = fitted.result();
+
+    let coefficients: Vec<f64> = result.coefficients.iter().copied().collect();
+    let intercept = if options.fit_intercept {
+        result.intercept
+    } else {
+        None
+    };
+
+    let core = FitResultCore {
+        coefficients,
+        intercept,
+        r_squared: result.r_squared,
+        adj_r_squared: result.adj_r_squared,
+        residual_std_error: result.rmse,
+        n_observations: n_valid,
+        n_features,
+    };
+
+    // Same inference projection as RANSAC: only emit fields the upstream
+    // RegressionResult actually populates.
+    let inference = if options.compute_inference {
+        result.std_errors.as_ref().map(|se| FitResultInference {
+            std_errors: se.iter().copied().collect(),
+            t_values: result
+                .t_statistics
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            p_values: result
+                .p_values
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            ci_lower: result
+                .conf_interval_lower
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            ci_upper: result
+                .conf_interval_upper
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            confidence_level: options.confidence_level,
+            f_statistic: Some(result.f_statistic),
+            f_pvalue: Some(result.f_pvalue),
+        })
+    } else {
+        None
+    };
+
+    Ok(TheilSenResult {
+        fit: FitResult {
+            core,
+            inference,
+            diagnostics: None,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(a: f64, b: f64, tol: f64) -> bool {
+        (a - b).abs() < tol
+    }
+
+    #[test]
+    fn fits_clean_linear_data() {
+        // y = 1 + 2x on clean data.
+        let x = vec![(0..30).map(|i| i as f64 * 0.2).collect::<Vec<_>>()];
+        let y: Vec<f64> = x[0].iter().map(|&xi| 1.0 + 2.0 * xi).collect();
+
+        let opts = TheilSenOptions {
+            random_state: 42,
+            ..TheilSenOptions::default()
+        };
+        let r = fit_theilsen(&y, &x, &opts).unwrap();
+
+        assert!(
+            approx(r.fit.core.coefficients[0], 2.0, 0.05),
+            "expected slope ≈ 2, got {}",
+            r.fit.core.coefficients[0]
+        );
+        assert!(approx(r.fit.core.intercept.unwrap(), 1.0, 0.1));
+    }
+
+    #[test]
+    fn robust_against_outliers() {
+        // 50 inliers on y = 1 + 2x plus 20 wild outliers.
+        let n_in = 50usize;
+        let n_out = 20usize;
+        let mut xs: Vec<f64> = (0..n_in).map(|i| i as f64 * 0.2).collect();
+        let mut ys: Vec<f64> = xs.iter().map(|&xi| 1.0 + 2.0 * xi).collect();
+        for i in 0..n_out {
+            xs.push(i as f64 * 0.1);
+            ys.push(50.0 + i as f64);
+        }
+
+        let x = vec![xs];
+        let opts = TheilSenOptions {
+            random_state: 42,
+            ..TheilSenOptions::default()
+        };
+        let r = fit_theilsen(&ys, &x, &opts).unwrap();
+
+        // Theil-Sen's high breakdown point should keep slope close to 2 despite
+        // outliers; tolerance is wider than RANSAC because Theil-Sen blends
+        // rather than excluding.
+        assert!(
+            approx(r.fit.core.coefficients[0], 2.0, 0.6),
+            "expected slope ≈ 2 despite outliers, got {}",
+            r.fit.core.coefficients[0]
+        );
+    }
+
+    #[test]
+    fn rejects_zero_max_subpopulation() {
+        let x = vec![vec![1.0, 2.0, 3.0, 4.0, 5.0]];
+        let y = vec![3.0, 5.0, 7.0, 9.0, 11.0];
+        let opts = TheilSenOptions {
+            max_subpopulation: 0,
+            ..TheilSenOptions::default()
+        };
+        let err = fit_theilsen(&y, &x, &opts).unwrap_err();
+        match err {
+            StatsError::InvalidInput(_) => {}
+            other => panic!("expected InvalidInput, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rejects_dimension_mismatch() {
+        let x = vec![vec![1.0, 2.0, 3.0]];
+        let y = vec![1.0, 2.0, 3.0, 4.0];
+        let err = fit_theilsen(&y, &x, &TheilSenOptions::default()).unwrap_err();
+        match err {
+            StatsError::DimensionMismatch { .. } => {}
+            other => panic!("expected DimensionMismatch, got {:?}", other),
+        }
+    }
+}

--- a/crates/anofox-stats-core/src/types.rs
+++ b/crates/anofox-stats-core/src/types.rs
@@ -303,6 +303,45 @@ impl Default for RansacOptions {
     }
 }
 
+/// Options for Theil-Sen robust regression
+#[derive(Debug, Clone)]
+pub struct TheilSenOptions {
+    /// Whether to fit an intercept term.
+    pub fit_intercept: bool,
+    /// Cap on the number of subsamples examined (sklearn default 10_000).
+    pub max_subpopulation: u32,
+    /// Subsample size. `None` → `n_features + 1` (the minimum for an OLS fit
+    /// with intercept), matching sklearn's default.
+    pub n_subsamples: Option<usize>,
+    /// Maximum iterations for the spatial-median solver.
+    pub max_iterations: u32,
+    /// Convergence tolerance on the spatial-median solver.
+    pub tolerance: f64,
+    /// Random seed for the trial subsampler.
+    pub random_state: u64,
+    /// Whether to compute inference statistics. Theil-Sen does not produce
+    /// analytical confidence intervals upstream; populated only when the
+    /// underlying RegressionResult exposes asymptotic SEs.
+    pub compute_inference: bool,
+    /// Confidence level (kept for API parity).
+    pub confidence_level: f64,
+}
+
+impl Default for TheilSenOptions {
+    fn default() -> Self {
+        Self {
+            fit_intercept: true,
+            max_subpopulation: 10_000,
+            n_subsamples: None,
+            max_iterations: 300,
+            tolerance: 1e-3,
+            random_state: 0,
+            compute_inference: false,
+            confidence_level: 0.95,
+        }
+    }
+}
+
 /// Convergence information for iterative methods
 #[derive(Debug, Clone)]
 pub struct ConvergenceInfo {


### PR DESCRIPTION
First layer of the Theil-Sen portion of #60. Same chain shape as the just-landed Huber (#67) and RANSAC (#74) chains.

## What this delivers
- \`crates/anofox-stats-core/src/models/theil_sen.rs\` — \`fit_theilsen(y, x, &TheilSenOptions) -> TheilSenResult\`.
- \`TheilSenOptions\` with the full upstream knob set (\`fit_intercept\`, \`max_subpopulation\`, \`n_subsamples\`, \`max_iterations\`, \`tolerance\`, \`random_state\`, \`compute_inference\`, \`confidence_level\`). Defaults match sklearn.
- \`TheilSenResult\` wraps \`FitResult\` — Theil-Sen has no consensus-set diagnostics to surface (upstream \`FittedTheilSen\` exposes only the standard \`RegressionResult\` and a \`with_intercept\` flag, unlike Huber's outlier mask / RANSAC's inlier mask + trial count). Kept as a distinct type so the FFI / downstream layers can add estimator-specific extras later without touching the other contracts.

## Verified locally
- \`cargo build --release\` clean.
- \`cargo fmt --all -- --check\` clean.
- \`cargo clippy --all-targets --all-features --release -- -D warnings\` clean.
- \`cargo test --release --workspace\` — 156/156 (+4 new Theil-Sen tests):
  - \`fits_clean_linear_data\` — slope ≈ 2 on noise-free \`y = 1 + 2x\`.
  - \`robust_against_outliers\` — 50 clean + 20 wild outliers; slope stays within 0.6 of 2. Theil-Sen blends rather than excluding, so its tolerance band is wider than RANSAC's.
  - \`rejects_zero_max_subpopulation\` — surfaces \`StatsError::InvalidInput\`.
  - \`rejects_dimension_mismatch\` — surfaces \`StatsError::DimensionMismatch\`.

## Coming next
- Layer 2: FFI surface.
- Layer 3: C++ aggregate + table function.
- Layer 4: fit_predict aggregate + window + macro.
- Layer 5: SQL tests + README updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)