### PR TITLE
Add Theil-Sen FFI surface (layer 2 of #60 — Theil-Sen)

### DIFF
--- a/crates/anofox-stats-core/src/models/mod.rs
+++ b/crates/anofox-stats-core/src/models/mod.rs
@@ -16,6 +16,7 @@ mod quantile;
 mod ransac;
 mod ridge;
 mod rls;
+mod theil_sen;
 mod wls;
 
 pub use aid::{compute_aid, compute_aid_anomalies};
@@ -34,4 +35,5 @@ pub use quantile::fit_quantile;
 pub use ransac::{fit_ransac, RansacResult};
 pub use ridge::fit_ridge;
 pub use rls::{fit_rls, RlsOptions, RlsState};
+pub use theil_sen::{fit_theilsen, TheilSenResult};
 pub use wls::fit_wls;

--- a/crates/anofox-stats-core/src/models/theil_sen.rs
+++ b/crates/anofox-stats-core/src/models/theil_sen.rs
@@ -1,0 +1,251 @@
+//! Theil-Sen robust regression wrapper.
+//!
+//! Wraps `anofox_regression::solvers::TheilSenRegressor` and reshapes its
+//! result into the workspace-local `FitResult`. Theil-Sen has no
+//! consensus-set diagnostics to surface (no inlier mask, no trial count) —
+//! the upstream `FittedTheilSen` exposes only the standard `RegressionResult`
+//! and a `with_intercept` flag.
+
+use crate::errors::{StatsError, StatsResult};
+use crate::types::{FitResult, FitResultCore, FitResultInference, TheilSenOptions};
+use anofox_regression::solvers::{FittedRegressor, Regressor, TheilSenRegressor};
+use faer::{Col, Mat};
+
+/// Theil-Sen regression fit. Identical fields to `FitResult` — kept as a
+/// distinct type so the FFI / downstream wrappers can grow estimator-specific
+/// extras later without touching the OLS / Huber / RANSAC contracts.
+#[derive(Debug, Clone)]
+pub struct TheilSenResult {
+    pub fit: FitResult,
+}
+
+/// Fit a Theil-Sen robust regression model.
+pub fn fit_theilsen(
+    y: &[f64],
+    x: &[Vec<f64>],
+    options: &TheilSenOptions,
+) -> StatsResult<TheilSenResult> {
+    if y.is_empty() {
+        return Err(StatsError::EmptyInput { field: "y" });
+    }
+    if x.is_empty() {
+        return Err(StatsError::EmptyInput { field: "x" });
+    }
+    if options.max_subpopulation == 0 {
+        return Err(StatsError::InvalidInput(
+            "max_subpopulation must be > 0".to_string(),
+        ));
+    }
+    if options.max_iterations == 0 {
+        return Err(StatsError::InvalidInput(
+            "max_iterations must be > 0".to_string(),
+        ));
+    }
+    if !(options.tolerance > 0.0 && options.tolerance.is_finite()) {
+        return Err(StatsError::InvalidInput(format!(
+            "tolerance must be finite and positive, got {}",
+            options.tolerance
+        )));
+    }
+
+    let n_obs = y.len();
+    let n_features = x.len();
+
+    for col in x.iter() {
+        if col.len() != n_obs {
+            return Err(StatsError::DimensionMismatch {
+                y_len: n_obs,
+                x_rows: col.len(),
+            });
+        }
+    }
+
+    let valid_indices: Vec<usize> = (0..n_obs)
+        .filter(|&i| {
+            !y[i].is_nan()
+                && !y[i].is_infinite()
+                && x.iter()
+                    .all(|col| !col[i].is_nan() && !col[i].is_infinite())
+        })
+        .collect();
+
+    if valid_indices.is_empty() {
+        return Err(StatsError::NoValidData);
+    }
+
+    let n_valid = valid_indices.len();
+    let p_eff = if options.fit_intercept {
+        n_features + 1
+    } else {
+        n_features
+    };
+    let effective_n_subsamples = options.n_subsamples.unwrap_or(p_eff).max(p_eff);
+    if n_valid < effective_n_subsamples {
+        return Err(StatsError::InsufficientData {
+            rows: n_valid,
+            cols: n_features,
+        });
+    }
+
+    let y_col = Col::from_fn(n_valid, |i| y[valid_indices[i]]);
+    let x_mat = Mat::from_fn(n_valid, n_features, |i, j| x[j][valid_indices[i]]);
+
+    let mut builder = TheilSenRegressor::builder()
+        .with_intercept(options.fit_intercept)
+        .max_subpopulation(options.max_subpopulation as usize)
+        .max_iter(options.max_iterations as usize)
+        .tolerance(options.tolerance)
+        .random_state(options.random_state);
+    if let Some(n) = options.n_subsamples {
+        builder = builder.n_subsamples(n);
+    }
+
+    let fitted = builder
+        .build()
+        .fit(&x_mat, &y_col)
+        .map_err(|e| StatsError::RegressError(format!("{:?}", e)))?;
+
+    let result = fitted.result();
+
+    let coefficients: Vec<f64> = result.coefficients.iter().copied().collect();
+    let intercept = if options.fit_intercept {
+        result.intercept
+    } else {
+        None
+    };
+
+    let core = FitResultCore {
+        coefficients,
+        intercept,
+        r_squared: result.r_squared,
+        adj_r_squared: result.adj_r_squared,
+        residual_std_error: result.rmse,
+        n_observations: n_valid,
+        n_features,
+    };
+
+    // Same inference projection as RANSAC: only emit fields the upstream
+    // RegressionResult actually populates.
+    let inference = if options.compute_inference {
+        result.std_errors.as_ref().map(|se| FitResultInference {
+            std_errors: se.iter().copied().collect(),
+            t_values: result
+                .t_statistics
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            p_values: result
+                .p_values
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            ci_lower: result
+                .conf_interval_lower
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            ci_upper: result
+                .conf_interval_upper
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            confidence_level: options.confidence_level,
+            f_statistic: Some(result.f_statistic),
+            f_pvalue: Some(result.f_pvalue),
+        })
+    } else {
+        None
+    };
+
+    Ok(TheilSenResult {
+        fit: FitResult {
+            core,
+            inference,
+            diagnostics: None,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(a: f64, b: f64, tol: f64) -> bool {
+        (a - b).abs() < tol
+    }
+
+    #[test]
+    fn fits_clean_linear_data() {
+        // y = 1 + 2x on clean data.
+        let x = vec![(0..30).map(|i| i as f64 * 0.2).collect::<Vec<_>>()];
+        let y: Vec<f64> = x[0].iter().map(|&xi| 1.0 + 2.0 * xi).collect();
+
+        let opts = TheilSenOptions {
+            random_state: 42,
+            ..TheilSenOptions::default()
+        };
+        let r = fit_theilsen(&y, &x, &opts).unwrap();
+
+        assert!(
+            approx(r.fit.core.coefficients[0], 2.0, 0.05),
+            "expected slope ≈ 2, got {}",
+            r.fit.core.coefficients[0]
+        );
+        assert!(approx(r.fit.core.intercept.unwrap(), 1.0, 0.1));
+    }
+
+    #[test]
+    fn robust_against_outliers() {
+        // 50 inliers on y = 1 + 2x plus 20 wild outliers.
+        let n_in = 50usize;
+        let n_out = 20usize;
+        let mut xs: Vec<f64> = (0..n_in).map(|i| i as f64 * 0.2).collect();
+        let mut ys: Vec<f64> = xs.iter().map(|&xi| 1.0 + 2.0 * xi).collect();
+        for i in 0..n_out {
+            xs.push(i as f64 * 0.1);
+            ys.push(50.0 + i as f64);
+        }
+
+        let x = vec![xs];
+        let opts = TheilSenOptions {
+            random_state: 42,
+            ..TheilSenOptions::default()
+        };
+        let r = fit_theilsen(&ys, &x, &opts).unwrap();
+
+        // Theil-Sen's high breakdown point should keep slope close to 2 despite
+        // outliers; tolerance is wider than RANSAC because Theil-Sen blends
+        // rather than excluding.
+        assert!(
+            approx(r.fit.core.coefficients[0], 2.0, 0.6),
+            "expected slope ≈ 2 despite outliers, got {}",
+            r.fit.core.coefficients[0]
+        );
+    }
+
+    #[test]
+    fn rejects_zero_max_subpopulation() {
+        let x = vec![vec![1.0, 2.0, 3.0, 4.0, 5.0]];
+        let y = vec![3.0, 5.0, 7.0, 9.0, 11.0];
+        let opts = TheilSenOptions {
+            max_subpopulation: 0,
+            ..TheilSenOptions::default()
+        };
+        let err = fit_theilsen(&y, &x, &opts).unwrap_err();
+        match err {
+            StatsError::InvalidInput(_) => {}
+            other => panic!("expected InvalidInput, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rejects_dimension_mismatch() {
+        let x = vec![vec![1.0, 2.0, 3.0]];
+        let y = vec![1.0, 2.0, 3.0, 4.0];
+        let err = fit_theilsen(&y, &x, &TheilSenOptions::default()).unwrap_err();
+        match err {
+            StatsError::DimensionMismatch { .. } => {}
+            other => panic!("expected DimensionMismatch, got {:?}", other),
+        }
+    }
+}

--- a/crates/anofox-stats-core/src/types.rs
+++ b/crates/anofox-stats-core/src/types.rs
@@ -303,6 +303,45 @@ impl Default for RansacOptions {
     }
 }
 
+/// Options for Theil-Sen robust regression
+#[derive(Debug, Clone)]
+pub struct TheilSenOptions {
+    /// Whether to fit an intercept term.
+    pub fit_intercept: bool,
+    /// Cap on the number of subsamples examined (sklearn default 10_000).
+    pub max_subpopulation: u32,
+    /// Subsample size. `None` → `n_features + 1` (the minimum for an OLS fit
+    /// with intercept), matching sklearn's default.
+    pub n_subsamples: Option<usize>,
+    /// Maximum iterations for the spatial-median solver.
+    pub max_iterations: u32,
+    /// Convergence tolerance on the spatial-median solver.
+    pub tolerance: f64,
+    /// Random seed for the trial subsampler.
+    pub random_state: u64,
+    /// Whether to compute inference statistics. Theil-Sen does not produce
+    /// analytical confidence intervals upstream; populated only when the
+    /// underlying RegressionResult exposes asymptotic SEs.
+    pub compute_inference: bool,
+    /// Confidence level (kept for API parity).
+    pub confidence_level: f64,
+}
+
+impl Default for TheilSenOptions {
+    fn default() -> Self {
+        Self {
+            fit_intercept: true,
+            max_subpopulation: 10_000,
+            n_subsamples: None,
+            max_iterations: 300,
+            tolerance: 1e-3,
+            random_state: 0,
+            compute_inference: false,
+            confidence_level: 0.95,
+        }
+    }
+}
+
 /// Convergence information for iterative methods
 #[derive(Debug, Clone)]
 pub struct ConvergenceInfo {

--- a/crates/anofox-stats-ffi/src/lib.rs
+++ b/crates/anofox-stats-ffi/src/lib.rs
@@ -11,13 +11,14 @@ use anofox_stats_core::{
     models::{
         compute_aid, compute_aid_anomalies, fit_alm, fit_binomial, fit_bls, fit_elasticnet,
         fit_huber, fit_isotonic, fit_lm_dynamic, fit_negbinomial, fit_ols, fit_pls, fit_poisson,
-        fit_quantile, fit_ransac, fit_ridge, fit_rls, fit_tweedie, fit_wls, predict, RlsOptions,
+        fit_quantile, fit_ransac, fit_ridge, fit_rls, fit_theilsen, fit_tweedie, fit_wls, predict,
+        RlsOptions,
     },
     AidOptions, AlmDistribution, AlmLoss, AlmOptions, BinomialLink, BinomialOptions, BlsOptions,
     ElasticNetOptions, HcType, HuberOptions, InformationCriterion, IsotonicOptions, LambdaScaling,
     LmDynamicOptions, NegBinomialOptions, OlsOptions, OutlierMethod, PlsOptions, PoissonLink,
     PoissonOptions, QuantileOptions, RansacOptions, RidgeOptions, SolverType, StatsError,
-    TweedieOptions, WlsOptions,
+    TheilSenOptions, TweedieOptions, WlsOptions,
 };
 use statrs::distribution::{ContinuousCDF, StudentsT};
 use std::slice;
@@ -781,6 +782,187 @@ pub unsafe extern "C" fn anofox_free_ransac_extras(extras: *mut RansacFitExtras)
         libc::free((*extras).inliers as *mut libc::c_void);
         (*extras).inliers = std::ptr::null_mut();
         (*extras).inliers_len = 0;
+    }
+}
+
+/// Fit a Theil-Sen robust regression model.
+///
+/// # Safety
+/// - `y` must be a valid DataArray
+/// - `x` must point to `x_count` valid DataArray structs
+/// - `out_core` must be a valid pointer
+/// - `out_inference` can be NULL if inference is not needed
+/// - `out_error` must be a valid pointer
+///
+/// Memory rules: on success, free `out_core` via `anofox_free_result_core`
+/// and `out_inference` via `anofox_free_result_inference`. There are no
+/// Theil-Sen-specific extras (no inlier mask / trial count to surface).
+/// On failure, partial allocations are rolled back before returning false.
+///
+/// # Returns
+/// `true` on success, `false` on error (check `out_error` for details).
+#[no_mangle]
+pub unsafe extern "C" fn anofox_theilsen_fit(
+    y: DataArray,
+    x: *const DataArray,
+    x_count: usize,
+    options: TheilSenOptionsFFI,
+    out_core: *mut FitResultCore,
+    out_inference: *mut FitResultInference,
+    out_error: *mut AnofoxError,
+) -> bool {
+    if !out_error.is_null() {
+        *out_error = AnofoxError::success();
+    }
+
+    if out_core.is_null() {
+        if !out_error.is_null() {
+            (*out_error).set(ErrorCode::InvalidInput, "out_core is NULL");
+        }
+        return false;
+    }
+
+    if x.is_null() || x_count == 0 {
+        if !out_error.is_null() {
+            (*out_error).set(ErrorCode::InvalidInput, "x is NULL or empty");
+        }
+        return false;
+    }
+
+    let y_vec = y.to_vec();
+    let x_arrays = slice::from_raw_parts(x, x_count);
+    let x_vecs: Vec<Vec<f64>> = x_arrays.iter().map(|arr| arr.to_vec()).collect();
+
+    let opts = TheilSenOptions {
+        fit_intercept: options.fit_intercept,
+        max_subpopulation: options.max_subpopulation,
+        n_subsamples: if options.n_subsamples_set {
+            Some(options.n_subsamples_value)
+        } else {
+            None
+        },
+        max_iterations: options.max_iterations,
+        tolerance: options.tolerance,
+        random_state: options.random_state,
+        compute_inference: options.compute_inference,
+        confidence_level: options.confidence_level,
+    };
+
+    let fit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        fit_theilsen(&y_vec, &x_vecs, &opts)
+    }));
+
+    let fit_result = match fit_result {
+        Ok(r) => r,
+        Err(_) => {
+            if !out_error.is_null() {
+                (*out_error).set(ErrorCode::InternalError, "Internal panic in Theil-Sen fit");
+            }
+            return false;
+        }
+    };
+
+    match fit_result {
+        Ok(ts) => {
+            let result = ts.fit;
+            let n_coef = result.core.coefficients.len();
+
+            let coef_ptr = libc::malloc(n_coef * std::mem::size_of::<f64>()) as *mut f64;
+            if coef_ptr.is_null() && n_coef > 0 {
+                if !out_error.is_null() {
+                    (*out_error).set(
+                        ErrorCode::AllocationFailure,
+                        "Failed to allocate coefficients",
+                    );
+                }
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(result.core.coefficients.as_ptr(), coef_ptr, n_coef);
+
+            (*out_core) = FitResultCore {
+                coefficients: coef_ptr,
+                coefficients_len: n_coef,
+                intercept: result.core.intercept.unwrap_or(f64::NAN),
+                r_squared: result.core.r_squared,
+                adj_r_squared: result.core.adj_r_squared,
+                residual_std_error: result.core.residual_std_error,
+                n_observations: result.core.n_observations,
+                n_features: result.core.n_features,
+            };
+
+            if !out_inference.is_null() {
+                if let Some(inf) = result.inference {
+                    let n = inf.std_errors.len();
+
+                    let std_err_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let t_val_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let p_val_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let ci_lo_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let ci_hi_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+
+                    if n > 0
+                        && (std_err_ptr.is_null()
+                            || t_val_ptr.is_null()
+                            || p_val_ptr.is_null()
+                            || ci_lo_ptr.is_null()
+                            || ci_hi_ptr.is_null())
+                    {
+                        if !std_err_ptr.is_null() {
+                            libc::free(std_err_ptr as *mut libc::c_void);
+                        }
+                        if !t_val_ptr.is_null() {
+                            libc::free(t_val_ptr as *mut libc::c_void);
+                        }
+                        if !p_val_ptr.is_null() {
+                            libc::free(p_val_ptr as *mut libc::c_void);
+                        }
+                        if !ci_lo_ptr.is_null() {
+                            libc::free(ci_lo_ptr as *mut libc::c_void);
+                        }
+                        if !ci_hi_ptr.is_null() {
+                            libc::free(ci_hi_ptr as *mut libc::c_void);
+                        }
+                        libc::free(coef_ptr as *mut libc::c_void);
+
+                        if !out_error.is_null() {
+                            (*out_error).set(
+                                ErrorCode::AllocationFailure,
+                                "Failed to allocate inference arrays",
+                            );
+                        }
+                        return false;
+                    }
+
+                    std::ptr::copy_nonoverlapping(inf.std_errors.as_ptr(), std_err_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.t_values.as_ptr(), t_val_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.p_values.as_ptr(), p_val_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.ci_lower.as_ptr(), ci_lo_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.ci_upper.as_ptr(), ci_hi_ptr, n);
+
+                    (*out_inference) = FitResultInference {
+                        std_errors: std_err_ptr,
+                        t_values: t_val_ptr,
+                        p_values: p_val_ptr,
+                        ci_lower: ci_lo_ptr,
+                        ci_upper: ci_hi_ptr,
+                        len: n,
+                        confidence_level: inf.confidence_level,
+                        f_statistic: inf.f_statistic.unwrap_or(f64::NAN),
+                        f_pvalue: inf.f_pvalue.unwrap_or(f64::NAN),
+                    };
+                } else {
+                    (*out_inference) = FitResultInference::default();
+                }
+            }
+
+            true
+        }
+        Err(e) => {
+            if !out_error.is_null() {
+                (*out_error).set(error_to_code(&e), &e.to_string());
+            }
+            false
+        }
     }
 }
 

--- a/crates/anofox-stats-ffi/src/types.rs
+++ b/crates/anofox-stats-ffi/src/types.rs
@@ -380,6 +380,41 @@ impl Default for RansacFitExtras {
     }
 }
 
+/// Theil-Sen robust regression options for FFI.
+///
+/// `n_subsamples_*` together encode Option<usize>: when `n_subsamples_set` is
+/// false the upstream solver picks `n_features + 1` (sklearn default).
+#[repr(C)]
+pub struct TheilSenOptionsFFI {
+    pub fit_intercept: bool,
+    pub compute_inference: bool,
+    pub confidence_level: f64,
+    /// Cap on the number of subsamples examined (sklearn default 10_000).
+    pub max_subpopulation: u32,
+    pub max_iterations: u32,
+    pub tolerance: f64,
+    pub random_state: u64,
+
+    pub n_subsamples_set: bool,
+    pub n_subsamples_value: usize,
+}
+
+impl Default for TheilSenOptionsFFI {
+    fn default() -> Self {
+        Self {
+            fit_intercept: true,
+            compute_inference: false,
+            confidence_level: 0.95,
+            max_subpopulation: 10_000,
+            max_iterations: 300,
+            tolerance: 1e-3,
+            random_state: 0,
+            n_subsamples_set: false,
+            n_subsamples_value: 0,
+        }
+    }
+}
+
 /// Ridge regression options for FFI
 #[repr(C)]
 pub struct RidgeOptionsFFI {

--- a/src/include/anofox_stats_ffi.h
+++ b/src/include/anofox_stats_ffi.h
@@ -306,6 +306,48 @@ bool anofox_ransac_fit(AnofoxDataArray y, const AnofoxDataArray *x, size_t x_cou
 void anofox_free_ransac_extras(AnofoxRansacFitExtras *extras);
 
 /**
+ * Theil-Sen robust regression options for FFI.
+ *
+ * `n_subsamples_set` / `n_subsamples_value` encode Rust's Option<usize>:
+ * when `n_subsamples_set` is false the upstream solver picks
+ * `n_features + 1` (sklearn default).
+ */
+typedef struct {
+    bool fit_intercept;
+    bool compute_inference;
+    double confidence_level;
+    /** Cap on the number of subsamples examined (sklearn default 10_000). */
+    uint32_t max_subpopulation;
+    uint32_t max_iterations;
+    double tolerance;
+    /** Random seed for the trial subsampler. */
+    uint64_t random_state;
+
+    bool n_subsamples_set;
+    size_t n_subsamples_value;
+} AnofoxTheilSenOptions;
+
+/**
+ * Fit a Theil-Sen robust regression model.
+ *
+ * Unlike Huber and RANSAC, Theil-Sen does not surface any consensus-set
+ * diagnostics — the FFI returns only the standard core / inference
+ * results.
+ *
+ * @param y Response variable array
+ * @param x Pointer to array of feature arrays
+ * @param x_count Number of feature arrays
+ * @param options Theil-Sen fitting options
+ * @param out_core Output: core fit results (required)
+ * @param out_inference Output: inference results (NULL if not needed)
+ * @param out_error Output: error information (required)
+ * @return true on success, false on error
+ */
+bool anofox_theilsen_fit(AnofoxDataArray y, const AnofoxDataArray *x, size_t x_count,
+                         AnofoxTheilSenOptions options, AnofoxFitResultCore *out_core,
+                         AnofoxFitResultInference *out_inference, AnofoxError *out_error);
+
+/**
  * Ridge regression options for FFI
  */
 typedef struct {


### PR DESCRIPTION
Layer 2 of the Theil-Sen chain. Stacked on #79; will be retargeted to \`main\` once #79 merges.

## What this delivers
- \`AnofoxTheilSenOptions\` FFI struct. The single Rust \`Option<usize>\` knob (\`n_subsamples\`) is encoded as an \`*_set\` + \`*_value\` pair.
- \`anofox_theilsen_fit\` extern "C" function with the same panic-safe + rollback-on-failure contract as the Huber/RANSAC FFI.
- No extras struct — Theil-Sen has no consensus-set diagnostics to surface. Core/inference are freed via the existing \`anofox_free_result_core\` / \`anofox_free_result_inference\` helpers.
- Matching C declarations in \`src/include/anofox_stats_ffi.h\`.

## Verified
- \`cargo build --release\` clean.
- \`cargo clippy --all-targets --all-features --release -- -D warnings\` clean.
- \`cargo fmt --all -- --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)