### PR TITLE
Add Theil-Sen C++ aggregate + table function (layer 3 of #60 — Theil-Sen)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ set(EXTENSION_SOURCES
     src/table_functions/wls_fit.cpp
     src/table_functions/huber_fit.cpp
     src/table_functions/ransac_fit.cpp
+    src/table_functions/theil_sen_fit.cpp
     src/table_functions/predict.cpp
     src/table_functions/rls_fit.cpp
     src/aggregate_functions/ols_aggregate.cpp
@@ -125,6 +126,7 @@ set(EXTENSION_SOURCES
     src/aggregate_functions/wls_aggregate.cpp
     src/aggregate_functions/huber_aggregate.cpp
     src/aggregate_functions/ransac_aggregate.cpp
+    src/aggregate_functions/theil_sen_aggregate.cpp
     src/aggregate_functions/rls_aggregate.cpp
     src/aggregate_functions/vif_aggregate.cpp
     src/aggregate_functions/jarque_bera_aggregate.cpp

--- a/crates/anofox-stats-core/src/models/mod.rs
+++ b/crates/anofox-stats-core/src/models/mod.rs
@@ -16,6 +16,7 @@ mod quantile;
 mod ransac;
 mod ridge;
 mod rls;
+mod theil_sen;
 mod wls;
 
 pub use aid::{compute_aid, compute_aid_anomalies};
@@ -34,4 +35,5 @@ pub use quantile::fit_quantile;
 pub use ransac::{fit_ransac, RansacResult};
 pub use ridge::fit_ridge;
 pub use rls::{fit_rls, RlsOptions, RlsState};
+pub use theil_sen::{fit_theilsen, TheilSenResult};
 pub use wls::fit_wls;

--- a/crates/anofox-stats-core/src/models/theil_sen.rs
+++ b/crates/anofox-stats-core/src/models/theil_sen.rs
@@ -1,0 +1,251 @@
+//! Theil-Sen robust regression wrapper.
+//!
+//! Wraps `anofox_regression::solvers::TheilSenRegressor` and reshapes its
+//! result into the workspace-local `FitResult`. Theil-Sen has no
+//! consensus-set diagnostics to surface (no inlier mask, no trial count) —
+//! the upstream `FittedTheilSen` exposes only the standard `RegressionResult`
+//! and a `with_intercept` flag.
+
+use crate::errors::{StatsError, StatsResult};
+use crate::types::{FitResult, FitResultCore, FitResultInference, TheilSenOptions};
+use anofox_regression::solvers::{FittedRegressor, Regressor, TheilSenRegressor};
+use faer::{Col, Mat};
+
+/// Theil-Sen regression fit. Identical fields to `FitResult` — kept as a
+/// distinct type so the FFI / downstream wrappers can grow estimator-specific
+/// extras later without touching the OLS / Huber / RANSAC contracts.
+#[derive(Debug, Clone)]
+pub struct TheilSenResult {
+    pub fit: FitResult,
+}
+
+/// Fit a Theil-Sen robust regression model.
+pub fn fit_theilsen(
+    y: &[f64],
+    x: &[Vec<f64>],
+    options: &TheilSenOptions,
+) -> StatsResult<TheilSenResult> {
+    if y.is_empty() {
+        return Err(StatsError::EmptyInput { field: "y" });
+    }
+    if x.is_empty() {
+        return Err(StatsError::EmptyInput { field: "x" });
+    }
+    if options.max_subpopulation == 0 {
+        return Err(StatsError::InvalidInput(
+            "max_subpopulation must be > 0".to_string(),
+        ));
+    }
+    if options.max_iterations == 0 {
+        return Err(StatsError::InvalidInput(
+            "max_iterations must be > 0".to_string(),
+        ));
+    }
+    if !(options.tolerance > 0.0 && options.tolerance.is_finite()) {
+        return Err(StatsError::InvalidInput(format!(
+            "tolerance must be finite and positive, got {}",
+            options.tolerance
+        )));
+    }
+
+    let n_obs = y.len();
+    let n_features = x.len();
+
+    for col in x.iter() {
+        if col.len() != n_obs {
+            return Err(StatsError::DimensionMismatch {
+                y_len: n_obs,
+                x_rows: col.len(),
+            });
+        }
+    }
+
+    let valid_indices: Vec<usize> = (0..n_obs)
+        .filter(|&i| {
+            !y[i].is_nan()
+                && !y[i].is_infinite()
+                && x.iter()
+                    .all(|col| !col[i].is_nan() && !col[i].is_infinite())
+        })
+        .collect();
+
+    if valid_indices.is_empty() {
+        return Err(StatsError::NoValidData);
+    }
+
+    let n_valid = valid_indices.len();
+    let p_eff = if options.fit_intercept {
+        n_features + 1
+    } else {
+        n_features
+    };
+    let effective_n_subsamples = options.n_subsamples.unwrap_or(p_eff).max(p_eff);
+    if n_valid < effective_n_subsamples {
+        return Err(StatsError::InsufficientData {
+            rows: n_valid,
+            cols: n_features,
+        });
+    }
+
+    let y_col = Col::from_fn(n_valid, |i| y[valid_indices[i]]);
+    let x_mat = Mat::from_fn(n_valid, n_features, |i, j| x[j][valid_indices[i]]);
+
+    let mut builder = TheilSenRegressor::builder()
+        .with_intercept(options.fit_intercept)
+        .max_subpopulation(options.max_subpopulation as usize)
+        .max_iter(options.max_iterations as usize)
+        .tolerance(options.tolerance)
+        .random_state(options.random_state);
+    if let Some(n) = options.n_subsamples {
+        builder = builder.n_subsamples(n);
+    }
+
+    let fitted = builder
+        .build()
+        .fit(&x_mat, &y_col)
+        .map_err(|e| StatsError::RegressError(format!("{:?}", e)))?;
+
+    let result = fitted.result();
+
+    let coefficients: Vec<f64> = result.coefficients.iter().copied().collect();
+    let intercept = if options.fit_intercept {
+        result.intercept
+    } else {
+        None
+    };
+
+    let core = FitResultCore {
+        coefficients,
+        intercept,
+        r_squared: result.r_squared,
+        adj_r_squared: result.adj_r_squared,
+        residual_std_error: result.rmse,
+        n_observations: n_valid,
+        n_features,
+    };
+
+    // Same inference projection as RANSAC: only emit fields the upstream
+    // RegressionResult actually populates.
+    let inference = if options.compute_inference {
+        result.std_errors.as_ref().map(|se| FitResultInference {
+            std_errors: se.iter().copied().collect(),
+            t_values: result
+                .t_statistics
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            p_values: result
+                .p_values
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            ci_lower: result
+                .conf_interval_lower
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            ci_upper: result
+                .conf_interval_upper
+                .as_ref()
+                .map(|c| c.iter().copied().collect())
+                .unwrap_or_else(|| vec![f64::NAN; n_features]),
+            confidence_level: options.confidence_level,
+            f_statistic: Some(result.f_statistic),
+            f_pvalue: Some(result.f_pvalue),
+        })
+    } else {
+        None
+    };
+
+    Ok(TheilSenResult {
+        fit: FitResult {
+            core,
+            inference,
+            diagnostics: None,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(a: f64, b: f64, tol: f64) -> bool {
+        (a - b).abs() < tol
+    }
+
+    #[test]
+    fn fits_clean_linear_data() {
+        // y = 1 + 2x on clean data.
+        let x = vec![(0..30).map(|i| i as f64 * 0.2).collect::<Vec<_>>()];
+        let y: Vec<f64> = x[0].iter().map(|&xi| 1.0 + 2.0 * xi).collect();
+
+        let opts = TheilSenOptions {
+            random_state: 42,
+            ..TheilSenOptions::default()
+        };
+        let r = fit_theilsen(&y, &x, &opts).unwrap();
+
+        assert!(
+            approx(r.fit.core.coefficients[0], 2.0, 0.05),
+            "expected slope ≈ 2, got {}",
+            r.fit.core.coefficients[0]
+        );
+        assert!(approx(r.fit.core.intercept.unwrap(), 1.0, 0.1));
+    }
+
+    #[test]
+    fn robust_against_outliers() {
+        // 50 inliers on y = 1 + 2x plus 20 wild outliers.
+        let n_in = 50usize;
+        let n_out = 20usize;
+        let mut xs: Vec<f64> = (0..n_in).map(|i| i as f64 * 0.2).collect();
+        let mut ys: Vec<f64> = xs.iter().map(|&xi| 1.0 + 2.0 * xi).collect();
+        for i in 0..n_out {
+            xs.push(i as f64 * 0.1);
+            ys.push(50.0 + i as f64);
+        }
+
+        let x = vec![xs];
+        let opts = TheilSenOptions {
+            random_state: 42,
+            ..TheilSenOptions::default()
+        };
+        let r = fit_theilsen(&ys, &x, &opts).unwrap();
+
+        // Theil-Sen's high breakdown point should keep slope close to 2 despite
+        // outliers; tolerance is wider than RANSAC because Theil-Sen blends
+        // rather than excluding.
+        assert!(
+            approx(r.fit.core.coefficients[0], 2.0, 0.6),
+            "expected slope ≈ 2 despite outliers, got {}",
+            r.fit.core.coefficients[0]
+        );
+    }
+
+    #[test]
+    fn rejects_zero_max_subpopulation() {
+        let x = vec![vec![1.0, 2.0, 3.0, 4.0, 5.0]];
+        let y = vec![3.0, 5.0, 7.0, 9.0, 11.0];
+        let opts = TheilSenOptions {
+            max_subpopulation: 0,
+            ..TheilSenOptions::default()
+        };
+        let err = fit_theilsen(&y, &x, &opts).unwrap_err();
+        match err {
+            StatsError::InvalidInput(_) => {}
+            other => panic!("expected InvalidInput, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rejects_dimension_mismatch() {
+        let x = vec![vec![1.0, 2.0, 3.0]];
+        let y = vec![1.0, 2.0, 3.0, 4.0];
+        let err = fit_theilsen(&y, &x, &TheilSenOptions::default()).unwrap_err();
+        match err {
+            StatsError::DimensionMismatch { .. } => {}
+            other => panic!("expected DimensionMismatch, got {:?}", other),
+        }
+    }
+}

--- a/crates/anofox-stats-core/src/types.rs
+++ b/crates/anofox-stats-core/src/types.rs
@@ -303,6 +303,45 @@ impl Default for RansacOptions {
     }
 }
 
+/// Options for Theil-Sen robust regression
+#[derive(Debug, Clone)]
+pub struct TheilSenOptions {
+    /// Whether to fit an intercept term.
+    pub fit_intercept: bool,
+    /// Cap on the number of subsamples examined (sklearn default 10_000).
+    pub max_subpopulation: u32,
+    /// Subsample size. `None` → `n_features + 1` (the minimum for an OLS fit
+    /// with intercept), matching sklearn's default.
+    pub n_subsamples: Option<usize>,
+    /// Maximum iterations for the spatial-median solver.
+    pub max_iterations: u32,
+    /// Convergence tolerance on the spatial-median solver.
+    pub tolerance: f64,
+    /// Random seed for the trial subsampler.
+    pub random_state: u64,
+    /// Whether to compute inference statistics. Theil-Sen does not produce
+    /// analytical confidence intervals upstream; populated only when the
+    /// underlying RegressionResult exposes asymptotic SEs.
+    pub compute_inference: bool,
+    /// Confidence level (kept for API parity).
+    pub confidence_level: f64,
+}
+
+impl Default for TheilSenOptions {
+    fn default() -> Self {
+        Self {
+            fit_intercept: true,
+            max_subpopulation: 10_000,
+            n_subsamples: None,
+            max_iterations: 300,
+            tolerance: 1e-3,
+            random_state: 0,
+            compute_inference: false,
+            confidence_level: 0.95,
+        }
+    }
+}
+
 /// Convergence information for iterative methods
 #[derive(Debug, Clone)]
 pub struct ConvergenceInfo {

--- a/crates/anofox-stats-ffi/src/lib.rs
+++ b/crates/anofox-stats-ffi/src/lib.rs
@@ -11,13 +11,14 @@ use anofox_stats_core::{
     models::{
         compute_aid, compute_aid_anomalies, fit_alm, fit_binomial, fit_bls, fit_elasticnet,
         fit_huber, fit_isotonic, fit_lm_dynamic, fit_negbinomial, fit_ols, fit_pls, fit_poisson,
-        fit_quantile, fit_ransac, fit_ridge, fit_rls, fit_tweedie, fit_wls, predict, RlsOptions,
+        fit_quantile, fit_ransac, fit_ridge, fit_rls, fit_theilsen, fit_tweedie, fit_wls, predict,
+        RlsOptions,
     },
     AidOptions, AlmDistribution, AlmLoss, AlmOptions, BinomialLink, BinomialOptions, BlsOptions,
     ElasticNetOptions, HcType, HuberOptions, InformationCriterion, IsotonicOptions, LambdaScaling,
     LmDynamicOptions, NegBinomialOptions, OlsOptions, OutlierMethod, PlsOptions, PoissonLink,
     PoissonOptions, QuantileOptions, RansacOptions, RidgeOptions, SolverType, StatsError,
-    TweedieOptions, WlsOptions,
+    TheilSenOptions, TweedieOptions, WlsOptions,
 };
 use statrs::distribution::{ContinuousCDF, StudentsT};
 use std::slice;
@@ -781,6 +782,187 @@ pub unsafe extern "C" fn anofox_free_ransac_extras(extras: *mut RansacFitExtras)
         libc::free((*extras).inliers as *mut libc::c_void);
         (*extras).inliers = std::ptr::null_mut();
         (*extras).inliers_len = 0;
+    }
+}
+
+/// Fit a Theil-Sen robust regression model.
+///
+/// # Safety
+/// - `y` must be a valid DataArray
+/// - `x` must point to `x_count` valid DataArray structs
+/// - `out_core` must be a valid pointer
+/// - `out_inference` can be NULL if inference is not needed
+/// - `out_error` must be a valid pointer
+///
+/// Memory rules: on success, free `out_core` via `anofox_free_result_core`
+/// and `out_inference` via `anofox_free_result_inference`. There are no
+/// Theil-Sen-specific extras (no inlier mask / trial count to surface).
+/// On failure, partial allocations are rolled back before returning false.
+///
+/// # Returns
+/// `true` on success, `false` on error (check `out_error` for details).
+#[no_mangle]
+pub unsafe extern "C" fn anofox_theilsen_fit(
+    y: DataArray,
+    x: *const DataArray,
+    x_count: usize,
+    options: TheilSenOptionsFFI,
+    out_core: *mut FitResultCore,
+    out_inference: *mut FitResultInference,
+    out_error: *mut AnofoxError,
+) -> bool {
+    if !out_error.is_null() {
+        *out_error = AnofoxError::success();
+    }
+
+    if out_core.is_null() {
+        if !out_error.is_null() {
+            (*out_error).set(ErrorCode::InvalidInput, "out_core is NULL");
+        }
+        return false;
+    }
+
+    if x.is_null() || x_count == 0 {
+        if !out_error.is_null() {
+            (*out_error).set(ErrorCode::InvalidInput, "x is NULL or empty");
+        }
+        return false;
+    }
+
+    let y_vec = y.to_vec();
+    let x_arrays = slice::from_raw_parts(x, x_count);
+    let x_vecs: Vec<Vec<f64>> = x_arrays.iter().map(|arr| arr.to_vec()).collect();
+
+    let opts = TheilSenOptions {
+        fit_intercept: options.fit_intercept,
+        max_subpopulation: options.max_subpopulation,
+        n_subsamples: if options.n_subsamples_set {
+            Some(options.n_subsamples_value)
+        } else {
+            None
+        },
+        max_iterations: options.max_iterations,
+        tolerance: options.tolerance,
+        random_state: options.random_state,
+        compute_inference: options.compute_inference,
+        confidence_level: options.confidence_level,
+    };
+
+    let fit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        fit_theilsen(&y_vec, &x_vecs, &opts)
+    }));
+
+    let fit_result = match fit_result {
+        Ok(r) => r,
+        Err(_) => {
+            if !out_error.is_null() {
+                (*out_error).set(ErrorCode::InternalError, "Internal panic in Theil-Sen fit");
+            }
+            return false;
+        }
+    };
+
+    match fit_result {
+        Ok(ts) => {
+            let result = ts.fit;
+            let n_coef = result.core.coefficients.len();
+
+            let coef_ptr = libc::malloc(n_coef * std::mem::size_of::<f64>()) as *mut f64;
+            if coef_ptr.is_null() && n_coef > 0 {
+                if !out_error.is_null() {
+                    (*out_error).set(
+                        ErrorCode::AllocationFailure,
+                        "Failed to allocate coefficients",
+                    );
+                }
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(result.core.coefficients.as_ptr(), coef_ptr, n_coef);
+
+            (*out_core) = FitResultCore {
+                coefficients: coef_ptr,
+                coefficients_len: n_coef,
+                intercept: result.core.intercept.unwrap_or(f64::NAN),
+                r_squared: result.core.r_squared,
+                adj_r_squared: result.core.adj_r_squared,
+                residual_std_error: result.core.residual_std_error,
+                n_observations: result.core.n_observations,
+                n_features: result.core.n_features,
+            };
+
+            if !out_inference.is_null() {
+                if let Some(inf) = result.inference {
+                    let n = inf.std_errors.len();
+
+                    let std_err_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let t_val_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let p_val_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let ci_lo_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+                    let ci_hi_ptr = libc::malloc(n * std::mem::size_of::<f64>()) as *mut f64;
+
+                    if n > 0
+                        && (std_err_ptr.is_null()
+                            || t_val_ptr.is_null()
+                            || p_val_ptr.is_null()
+                            || ci_lo_ptr.is_null()
+                            || ci_hi_ptr.is_null())
+                    {
+                        if !std_err_ptr.is_null() {
+                            libc::free(std_err_ptr as *mut libc::c_void);
+                        }
+                        if !t_val_ptr.is_null() {
+                            libc::free(t_val_ptr as *mut libc::c_void);
+                        }
+                        if !p_val_ptr.is_null() {
+                            libc::free(p_val_ptr as *mut libc::c_void);
+                        }
+                        if !ci_lo_ptr.is_null() {
+                            libc::free(ci_lo_ptr as *mut libc::c_void);
+                        }
+                        if !ci_hi_ptr.is_null() {
+                            libc::free(ci_hi_ptr as *mut libc::c_void);
+                        }
+                        libc::free(coef_ptr as *mut libc::c_void);
+
+                        if !out_error.is_null() {
+                            (*out_error).set(
+                                ErrorCode::AllocationFailure,
+                                "Failed to allocate inference arrays",
+                            );
+                        }
+                        return false;
+                    }
+
+                    std::ptr::copy_nonoverlapping(inf.std_errors.as_ptr(), std_err_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.t_values.as_ptr(), t_val_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.p_values.as_ptr(), p_val_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.ci_lower.as_ptr(), ci_lo_ptr, n);
+                    std::ptr::copy_nonoverlapping(inf.ci_upper.as_ptr(), ci_hi_ptr, n);
+
+                    (*out_inference) = FitResultInference {
+                        std_errors: std_err_ptr,
+                        t_values: t_val_ptr,
+                        p_values: p_val_ptr,
+                        ci_lower: ci_lo_ptr,
+                        ci_upper: ci_hi_ptr,
+                        len: n,
+                        confidence_level: inf.confidence_level,
+                        f_statistic: inf.f_statistic.unwrap_or(f64::NAN),
+                        f_pvalue: inf.f_pvalue.unwrap_or(f64::NAN),
+                    };
+                } else {
+                    (*out_inference) = FitResultInference::default();
+                }
+            }
+
+            true
+        }
+        Err(e) => {
+            if !out_error.is_null() {
+                (*out_error).set(error_to_code(&e), &e.to_string());
+            }
+            false
+        }
     }
 }
 

--- a/crates/anofox-stats-ffi/src/types.rs
+++ b/crates/anofox-stats-ffi/src/types.rs
@@ -380,6 +380,41 @@ impl Default for RansacFitExtras {
     }
 }
 
+/// Theil-Sen robust regression options for FFI.
+///
+/// `n_subsamples_*` together encode Option<usize>: when `n_subsamples_set` is
+/// false the upstream solver picks `n_features + 1` (sklearn default).
+#[repr(C)]
+pub struct TheilSenOptionsFFI {
+    pub fit_intercept: bool,
+    pub compute_inference: bool,
+    pub confidence_level: f64,
+    /// Cap on the number of subsamples examined (sklearn default 10_000).
+    pub max_subpopulation: u32,
+    pub max_iterations: u32,
+    pub tolerance: f64,
+    pub random_state: u64,
+
+    pub n_subsamples_set: bool,
+    pub n_subsamples_value: usize,
+}
+
+impl Default for TheilSenOptionsFFI {
+    fn default() -> Self {
+        Self {
+            fit_intercept: true,
+            compute_inference: false,
+            confidence_level: 0.95,
+            max_subpopulation: 10_000,
+            max_iterations: 300,
+            tolerance: 1e-3,
+            random_state: 0,
+            n_subsamples_set: false,
+            n_subsamples_value: 0,
+        }
+    }
+}
+
 /// Ridge regression options for FFI
 #[repr(C)]
 pub struct RidgeOptionsFFI {

--- a/src/aggregate_functions/theil_sen_aggregate.cpp
+++ b/src/aggregate_functions/theil_sen_aggregate.cpp
@@ -1,0 +1,427 @@
+#include <vector>
+
+#include "duckdb.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/function/aggregate_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_aggregate_function_info.hpp"
+
+#include "../include/anofox_stats_ffi.h"
+#include "../include/ffi_enum_converters.hpp"
+#include "../include/map_options_parser.hpp"
+#include "telemetry.hpp"
+
+namespace duckdb {
+
+//===--------------------------------------------------------------------===//
+// Theil-Sen aggregate state. The single Option<usize> knob (n_subsamples)
+// is stored as a have/value pair that the FFI flattens back at Finalize.
+//===--------------------------------------------------------------------===//
+struct TheilSenAggregateState {
+    vector<double> y_values;
+    vector<vector<double>> x_columns;
+    idx_t n_features;
+    bool initialized;
+
+    bool fit_intercept;
+    bool compute_inference;
+    double confidence_level;
+    uint32_t max_subpopulation;
+    uint32_t max_iterations;
+    double tolerance;
+    uint64_t random_state;
+
+    bool n_subsamples_set;
+    uint32_t n_subsamples_value;
+
+    TheilSenAggregateState()
+        : n_features(0), initialized(false), fit_intercept(true), compute_inference(false),
+          confidence_level(0.95), max_subpopulation(10000), max_iterations(300), tolerance(1e-3), random_state(0),
+          n_subsamples_set(false), n_subsamples_value(0) {}
+
+    void Reset() {
+        y_values.clear();
+        x_columns.clear();
+        n_features = 0;
+        initialized = false;
+    }
+};
+
+struct TheilSenAggregateBindData : public FunctionData {
+    bool fit_intercept = true;
+    bool compute_inference = false;
+    double confidence_level = 0.95;
+    uint32_t max_subpopulation = 10000;
+    uint32_t max_iterations = 300;
+    double tolerance = 1e-3;
+    uint64_t random_state = 0;
+    bool n_subsamples_set = false;
+    uint32_t n_subsamples_value = 0;
+
+    unique_ptr<FunctionData> Copy() const override {
+        auto result = make_uniq<TheilSenAggregateBindData>();
+        result->fit_intercept = fit_intercept;
+        result->compute_inference = compute_inference;
+        result->confidence_level = confidence_level;
+        result->max_subpopulation = max_subpopulation;
+        result->max_iterations = max_iterations;
+        result->tolerance = tolerance;
+        result->random_state = random_state;
+        result->n_subsamples_set = n_subsamples_set;
+        result->n_subsamples_value = n_subsamples_value;
+        return std::move(result);
+    }
+
+    bool Equals(const FunctionData &other_p) const override {
+        auto &o = other_p.Cast<TheilSenAggregateBindData>();
+        return fit_intercept == o.fit_intercept && compute_inference == o.compute_inference &&
+               confidence_level == o.confidence_level && max_subpopulation == o.max_subpopulation &&
+               max_iterations == o.max_iterations && tolerance == o.tolerance &&
+               random_state == o.random_state && n_subsamples_set == o.n_subsamples_set &&
+               n_subsamples_value == o.n_subsamples_value;
+    }
+};
+
+// Result shape: standard fit fields, no Theil-Sen-specific extras (no inlier
+// mask / trial count to surface).
+static LogicalType GetTheilSenAggResultType(bool compute_inference) {
+    child_list_t<LogicalType> children;
+
+    children.push_back(make_pair("coefficients", LogicalType::LIST(LogicalType::DOUBLE)));
+    children.push_back(make_pair("intercept", LogicalType::DOUBLE));
+    children.push_back(make_pair("r_squared", LogicalType::DOUBLE));
+    children.push_back(make_pair("adj_r_squared", LogicalType::DOUBLE));
+    children.push_back(make_pair("residual_std_error", LogicalType::DOUBLE));
+    children.push_back(make_pair("n_observations", LogicalType::BIGINT));
+    children.push_back(make_pair("n_features", LogicalType::BIGINT));
+
+    if (compute_inference) {
+        children.push_back(make_pair("std_errors", LogicalType::LIST(LogicalType::DOUBLE)));
+        children.push_back(make_pair("t_values", LogicalType::LIST(LogicalType::DOUBLE)));
+        children.push_back(make_pair("p_values", LogicalType::LIST(LogicalType::DOUBLE)));
+        children.push_back(make_pair("ci_lower", LogicalType::LIST(LogicalType::DOUBLE)));
+        children.push_back(make_pair("ci_upper", LogicalType::LIST(LogicalType::DOUBLE)));
+        children.push_back(make_pair("f_statistic", LogicalType::DOUBLE));
+        children.push_back(make_pair("f_pvalue", LogicalType::DOUBLE));
+    }
+
+    return LogicalType::STRUCT(std::move(children));
+}
+
+static void TheilSenAggInitialize(const AggregateFunction &, data_ptr_t state_p) {
+    new (state_p) TheilSenAggregateState();
+}
+
+static void TheilSenAggDestroy(Vector &state_vector, AggregateInputData &, idx_t count) {
+    UnifiedVectorFormat sdata;
+    state_vector.ToUnifiedFormat(count, sdata);
+    auto states = (TheilSenAggregateState **)sdata.data;
+
+    for (idx_t i = 0; i < count; i++) {
+        auto &state = *states[sdata.sel->get_index(i)];
+        state.~TheilSenAggregateState();
+    }
+}
+
+static void TheilSenAggUpdate(Vector inputs[], AggregateInputData &aggr_input_data, idx_t input_count,
+                              Vector &state_vector, idx_t count) {
+    auto &bind_data = aggr_input_data.bind_data->Cast<TheilSenAggregateBindData>();
+
+    UnifiedVectorFormat y_data;
+    UnifiedVectorFormat x_data;
+    inputs[0].ToUnifiedFormat(count, y_data);
+    inputs[1].ToUnifiedFormat(count, x_data);
+
+    auto y_values = UnifiedVectorFormat::GetData<double>(y_data);
+    auto x_list_data = ListVector::GetData(inputs[1]);
+    auto &x_child = ListVector::GetEntry(inputs[1]);
+    auto x_child_data = FlatVector::GetData<double>(x_child);
+
+    UnifiedVectorFormat sdata;
+    state_vector.ToUnifiedFormat(count, sdata);
+    auto states = (TheilSenAggregateState **)sdata.data;
+
+    for (idx_t i = 0; i < count; i++) {
+        auto &state = *states[sdata.sel->get_index(i)];
+
+        state.fit_intercept = bind_data.fit_intercept;
+        state.compute_inference = bind_data.compute_inference;
+        state.confidence_level = bind_data.confidence_level;
+        state.max_subpopulation = bind_data.max_subpopulation;
+        state.max_iterations = bind_data.max_iterations;
+        state.tolerance = bind_data.tolerance;
+        state.random_state = bind_data.random_state;
+        state.n_subsamples_set = bind_data.n_subsamples_set;
+        state.n_subsamples_value = bind_data.n_subsamples_value;
+
+        auto y_idx = y_data.sel->get_index(i);
+        if (!y_data.validity.RowIsValid(y_idx)) {
+            continue;
+        }
+        double y_val = y_values[y_idx];
+
+        auto x_idx = x_data.sel->get_index(i);
+        if (!x_data.validity.RowIsValid(x_idx)) {
+            continue;
+        }
+
+        auto list_entry = x_list_data[x_idx];
+        idx_t n_features = list_entry.length;
+
+        if (!state.initialized) {
+            state.n_features = n_features;
+            state.x_columns.resize(n_features);
+            state.initialized = true;
+        }
+
+        if (n_features != state.n_features) {
+            throw InvalidInputException("Inconsistent feature count: expected %lu, got %lu", state.n_features,
+                                        n_features);
+        }
+
+        state.y_values.push_back(y_val);
+        for (idx_t j = 0; j < n_features; j++) {
+            double x_val = x_child_data[list_entry.offset + j];
+            state.x_columns[j].push_back(x_val);
+        }
+    }
+}
+
+static void TheilSenAggCombine(Vector &source_vector, Vector &target_vector, AggregateInputData &, idx_t count) {
+    UnifiedVectorFormat source_data, target_data;
+    source_vector.ToUnifiedFormat(count, source_data);
+    target_vector.ToUnifiedFormat(count, target_data);
+
+    auto sources = (TheilSenAggregateState **)source_data.data;
+    auto targets = (TheilSenAggregateState **)target_data.data;
+
+    for (idx_t i = 0; i < count; i++) {
+        auto &source = *sources[source_data.sel->get_index(i)];
+        auto &target = *targets[target_data.sel->get_index(i)];
+
+        if (!source.initialized) {
+            continue;
+        }
+
+        if (!target.initialized) {
+            target.y_values = std::move(source.y_values);
+            target.x_columns = std::move(source.x_columns);
+            target.n_features = source.n_features;
+            target.initialized = true;
+            target.fit_intercept = source.fit_intercept;
+            target.compute_inference = source.compute_inference;
+            target.confidence_level = source.confidence_level;
+            target.max_subpopulation = source.max_subpopulation;
+            target.max_iterations = source.max_iterations;
+            target.tolerance = source.tolerance;
+            target.random_state = source.random_state;
+            target.n_subsamples_set = source.n_subsamples_set;
+            target.n_subsamples_value = source.n_subsamples_value;
+            continue;
+        }
+
+        if (source.n_features != target.n_features) {
+            throw InvalidInputException("Cannot combine states with different feature counts: %lu vs %lu",
+                                        source.n_features, target.n_features);
+        }
+
+        target.y_values.insert(target.y_values.end(), source.y_values.begin(), source.y_values.end());
+        for (idx_t j = 0; j < target.n_features; j++) {
+            target.x_columns[j].insert(target.x_columns[j].end(), source.x_columns[j].begin(),
+                                       source.x_columns[j].end());
+        }
+    }
+}
+
+static void SetListInResult(Vector &list_vec, idx_t row, double *data, size_t len) {
+    auto &child = ListVector::GetEntry(list_vec);
+    auto offset = ListVector::GetListSize(list_vec);
+    ListVector::SetListSize(list_vec, offset + len);
+    auto vec_data = FlatVector::GetData<double>(child);
+    for (size_t i = 0; i < len; i++) {
+        vec_data[offset + i] = data[i];
+    }
+    ListVector::GetData(list_vec)[row] = {offset, (idx_t)len};
+}
+
+static void TheilSenAggFinalize(Vector &state_vector, AggregateInputData &aggr_input_data, Vector &result,
+                                idx_t count, idx_t offset) {
+    UnifiedVectorFormat sdata;
+    state_vector.ToUnifiedFormat(count, sdata);
+    auto states = (TheilSenAggregateState **)sdata.data;
+
+    auto &struct_entries = StructVector::GetEntries(result);
+
+    for (idx_t i = 0; i < count; i++) {
+        auto &state = *states[sdata.sel->get_index(i)];
+        idx_t result_idx = i + offset;
+
+        if (!state.initialized || state.y_values.size() < 2) {
+            FlatVector::SetNull(result, result_idx, true);
+            continue;
+        }
+
+        AnofoxDataArray y_array;
+        y_array.data = state.y_values.data();
+        y_array.validity = nullptr;
+        y_array.len = state.y_values.size();
+
+        vector<AnofoxDataArray> x_arrays;
+        for (auto &col : state.x_columns) {
+            AnofoxDataArray arr;
+            arr.data = col.data();
+            arr.validity = nullptr;
+            arr.len = col.size();
+            x_arrays.push_back(arr);
+        }
+
+        AnofoxTheilSenOptions options;
+        options.fit_intercept = state.fit_intercept;
+        options.compute_inference = state.compute_inference;
+        options.confidence_level = state.confidence_level;
+        options.max_subpopulation = state.max_subpopulation;
+        options.max_iterations = state.max_iterations;
+        options.tolerance = state.tolerance;
+        options.random_state = state.random_state;
+        options.n_subsamples_set = state.n_subsamples_set;
+        options.n_subsamples_value = state.n_subsamples_value;
+
+        AnofoxFitResultCore core_result;
+        AnofoxFitResultInference inference_result;
+        AnofoxError error;
+
+        bool success = anofox_theilsen_fit(y_array, x_arrays.data(), x_arrays.size(), options, &core_result,
+                                           state.compute_inference ? &inference_result : nullptr, &error);
+
+        if (!success) {
+            FlatVector::SetNull(result, result_idx, true);
+            continue;
+        }
+
+        idx_t struct_idx = 0;
+
+        SetListInResult(*struct_entries[struct_idx++], result_idx, core_result.coefficients,
+                        core_result.coefficients_len);
+
+        FlatVector::GetData<double>(*struct_entries[struct_idx++])[result_idx] = core_result.intercept;
+        FlatVector::GetData<double>(*struct_entries[struct_idx++])[result_idx] = core_result.r_squared;
+        FlatVector::GetData<double>(*struct_entries[struct_idx++])[result_idx] = core_result.adj_r_squared;
+        FlatVector::GetData<double>(*struct_entries[struct_idx++])[result_idx] = core_result.residual_std_error;
+        FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_observations;
+        FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_features;
+
+        if (state.compute_inference) {
+            SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.std_errors,
+                            inference_result.len);
+            SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.t_values,
+                            inference_result.len);
+            SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.p_values,
+                            inference_result.len);
+            SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.ci_lower,
+                            inference_result.len);
+            SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.ci_upper,
+                            inference_result.len);
+
+            FlatVector::GetData<double>(*struct_entries[struct_idx++])[result_idx] = inference_result.f_statistic;
+            FlatVector::GetData<double>(*struct_entries[struct_idx++])[result_idx] = inference_result.f_pvalue;
+
+            anofox_free_result_inference(&inference_result);
+        }
+
+        anofox_free_result_core(&core_result);
+        state.Reset();
+    }
+}
+
+static void ExtractTheilSenOptions(ClientContext &context, Expression &opts_expr,
+                                   TheilSenAggregateBindData &result) {
+    auto opts = RegressionMapOptions::ParseFromExpression(context, opts_expr);
+    if (opts.fit_intercept.has_value()) {
+        result.fit_intercept = opts.fit_intercept.value();
+    }
+    if (opts.compute_inference.has_value()) {
+        result.compute_inference = opts.compute_inference.value();
+    }
+    if (opts.confidence_level.has_value()) {
+        result.confidence_level = opts.confidence_level.value();
+    }
+    if (opts.max_subpopulation.has_value()) {
+        result.max_subpopulation = opts.max_subpopulation.value();
+    }
+    if (opts.max_iterations.has_value()) {
+        result.max_iterations = opts.max_iterations.value();
+    }
+    if (opts.tolerance.has_value()) {
+        result.tolerance = opts.tolerance.value();
+    }
+    if (opts.random_state.has_value()) {
+        result.random_state = opts.random_state.value();
+    }
+    if (opts.n_subsamples.has_value()) {
+        result.n_subsamples_set = true;
+        result.n_subsamples_value = opts.n_subsamples.value();
+    }
+}
+
+static unique_ptr<FunctionData> TheilSenAggBind(ClientContext &context, AggregateFunction &function,
+                                                vector<unique_ptr<Expression>> &arguments) {
+    auto result = make_uniq<TheilSenAggregateBindData>();
+
+    if (arguments.size() >= 3 && arguments[2]->IsFoldable()) {
+        ExtractTheilSenOptions(context, *arguments[2], *result);
+    }
+
+    function.return_type = GetTheilSenAggResultType(result->compute_inference);
+
+    PostHogTelemetry::Instance().CaptureFunctionExecution("theilsen_fit_agg");
+    return std::move(result);
+}
+
+void RegisterTheilSenAggregateFunction(ExtensionLoader &loader) {
+    AggregateFunctionSet func_set("anofox_stats_theilsen_fit_agg");
+
+    auto basic_func = AggregateFunction(
+        "anofox_stats_theilsen_fit_agg", {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)},
+        LogicalType::ANY, AggregateFunction::StateSize<TheilSenAggregateState>, TheilSenAggInitialize,
+        TheilSenAggUpdate, TheilSenAggCombine, TheilSenAggFinalize, nullptr, TheilSenAggBind, TheilSenAggDestroy);
+    func_set.AddFunction(basic_func);
+
+    auto map_func = AggregateFunction(
+        "anofox_stats_theilsen_fit_agg",
+        {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY}, LogicalType::ANY,
+        AggregateFunction::StateSize<TheilSenAggregateState>, TheilSenAggInitialize, TheilSenAggUpdate,
+        TheilSenAggCombine, TheilSenAggFinalize, nullptr, TheilSenAggBind, TheilSenAggDestroy);
+    func_set.AddFunction(map_func);
+
+    CreateAggregateFunctionInfo info(std::move(func_set));
+    info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+    FunctionDescription d1;
+    d1.description =
+        "Fits a Theil-Sen robust regression model and returns coefficients and fit statistics as a struct.";
+    d1.examples = {"anofox_stats_theilsen_fit_agg(y, x, {'random_state': 42, 'max_subpopulation': 5000})"};
+    d1.categories = {"regression"};
+    d1.parameter_names = {"y", "x", "options"};
+    d1.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE), LogicalType::ANY};
+    info.descriptions.push_back(std::move(d1));
+    FunctionDescription d2;
+    d2.description =
+        "Fits a Theil-Sen robust regression model and returns coefficients and fit statistics as a struct.";
+    d2.examples = {"anofox_stats_theilsen_fit_agg(y, x)"};
+    d2.categories = {"regression"};
+    d2.parameter_names = {"y", "x"};
+    d2.parameter_types = {LogicalType::DOUBLE, LogicalType::LIST(LogicalType::DOUBLE)};
+    info.descriptions.push_back(std::move(d2));
+    loader.RegisterFunction(std::move(info));
+
+    {
+        AggregateFunctionSet alias_set("theilsen_fit_agg");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateAggregateFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_theilsen_fit_agg";
+        loader.RegisterFunction(std::move(alias_info));
+    }
+}
+
+} // namespace duckdb

--- a/src/anofox_statistics_extension.cpp
+++ b/src/anofox_statistics_extension.cpp
@@ -71,6 +71,7 @@ void LoadInternal(ExtensionLoader &loader) {
     RegisterWlsFitFunction(loader);
     RegisterHuberFitFunction(loader);
     RegisterRansacFitFunction(loader);
+    RegisterTheilSenFitFunction(loader);
     RegisterPredictFunction(loader);
     RegisterRlsFitFunction(loader);
 
@@ -81,6 +82,7 @@ void LoadInternal(ExtensionLoader &loader) {
     RegisterWlsAggregateFunction(loader);
     RegisterHuberAggregateFunction(loader);
     RegisterRansacAggregateFunction(loader);
+    RegisterTheilSenAggregateFunction(loader);
     RegisterRlsAggregateFunction(loader);
     RegisterVifAggregateFunction(loader);
     RegisterJarqueBeraAggregateFunction(loader);

--- a/src/include/anofox_statistics_extension.hpp
+++ b/src/include/anofox_statistics_extension.hpp
@@ -13,6 +13,7 @@ void RegisterElasticNetFitFunction(ExtensionLoader &loader);
 void RegisterWlsFitFunction(ExtensionLoader &loader);
 void RegisterHuberFitFunction(ExtensionLoader &loader);
 void RegisterRansacFitFunction(ExtensionLoader &loader);
+void RegisterTheilSenFitFunction(ExtensionLoader &loader);
 void RegisterPredictFunction(ExtensionLoader &loader);
 void RegisterOlsAggregateFunction(ExtensionLoader &loader);
 void RegisterRidgeAggregateFunction(ExtensionLoader &loader);
@@ -20,6 +21,7 @@ void RegisterElasticNetAggregateFunction(ExtensionLoader &loader);
 void RegisterWlsAggregateFunction(ExtensionLoader &loader);
 void RegisterHuberAggregateFunction(ExtensionLoader &loader);
 void RegisterRansacAggregateFunction(ExtensionLoader &loader);
+void RegisterTheilSenAggregateFunction(ExtensionLoader &loader);
 void RegisterRlsAggregateFunction(ExtensionLoader &loader);
 void RegisterRlsFitFunction(ExtensionLoader &loader);
 

--- a/src/include/anofox_stats_ffi.h
+++ b/src/include/anofox_stats_ffi.h
@@ -306,6 +306,48 @@ bool anofox_ransac_fit(AnofoxDataArray y, const AnofoxDataArray *x, size_t x_cou
 void anofox_free_ransac_extras(AnofoxRansacFitExtras *extras);
 
 /**
+ * Theil-Sen robust regression options for FFI.
+ *
+ * `n_subsamples_set` / `n_subsamples_value` encode Rust's Option<usize>:
+ * when `n_subsamples_set` is false the upstream solver picks
+ * `n_features + 1` (sklearn default).
+ */
+typedef struct {
+    bool fit_intercept;
+    bool compute_inference;
+    double confidence_level;
+    /** Cap on the number of subsamples examined (sklearn default 10_000). */
+    uint32_t max_subpopulation;
+    uint32_t max_iterations;
+    double tolerance;
+    /** Random seed for the trial subsampler. */
+    uint64_t random_state;
+
+    bool n_subsamples_set;
+    size_t n_subsamples_value;
+} AnofoxTheilSenOptions;
+
+/**
+ * Fit a Theil-Sen robust regression model.
+ *
+ * Unlike Huber and RANSAC, Theil-Sen does not surface any consensus-set
+ * diagnostics — the FFI returns only the standard core / inference
+ * results.
+ *
+ * @param y Response variable array
+ * @param x Pointer to array of feature arrays
+ * @param x_count Number of feature arrays
+ * @param options Theil-Sen fitting options
+ * @param out_core Output: core fit results (required)
+ * @param out_inference Output: inference results (NULL if not needed)
+ * @param out_error Output: error information (required)
+ * @return true on success, false on error
+ */
+bool anofox_theilsen_fit(AnofoxDataArray y, const AnofoxDataArray *x, size_t x_count,
+                         AnofoxTheilSenOptions options, AnofoxFitResultCore *out_core,
+                         AnofoxFitResultInference *out_inference, AnofoxError *out_error);
+
+/**
  * Ridge regression options for FFI
  */
 typedef struct {

--- a/src/include/map_options_parser.cpp
+++ b/src/include/map_options_parser.cpp
@@ -333,6 +333,10 @@ RegressionMapOptions RegressionMapOptions::ParseFromValue(const Value &map_value
                 result.min_samples = ExtractUInt32(val);
             } else if (key == "random_state" || key == "seed") {
                 result.random_state = ExtractUInt64(val);
+            } else if (key == "max_subpopulation") {
+                result.max_subpopulation = ExtractUInt32(val);
+            } else if (key == "n_subsamples") {
+                result.n_subsamples = ExtractUInt32(val);
             } else if (key == "forgetting_factor") {
                 result.forgetting_factor = ExtractDouble(val);
             } else if (key == "initial_p_diagonal" || key == "p_diagonal") {
@@ -442,6 +446,10 @@ RegressionMapOptions RegressionMapOptions::ParseFromValue(const Value &map_value
                 result.min_samples = ExtractUInt32(val);
             } else if (key == "random_state" || key == "seed") {
                 result.random_state = ExtractUInt64(val);
+            } else if (key == "max_subpopulation") {
+                result.max_subpopulation = ExtractUInt32(val);
+            } else if (key == "n_subsamples") {
+                result.n_subsamples = ExtractUInt32(val);
             } else if (key == "forgetting_factor") {
                 result.forgetting_factor = ExtractDouble(val);
             } else if (key == "initial_p_diagonal" || key == "p_diagonal") {

--- a/src/include/map_options_parser.hpp
+++ b/src/include/map_options_parser.hpp
@@ -170,6 +170,10 @@ struct RegressionMapOptions {
     std::optional<uint32_t> min_samples;       // Subsample size per trial; None → n_features + 1
     std::optional<uint64_t> random_state;      // Seed for the trial subsampler
 
+    // Theil-Sen specific
+    std::optional<uint32_t> max_subpopulation;  // Cap on subsamples examined (sklearn default 10_000)
+    std::optional<uint32_t> n_subsamples;       // Subsample size; None → n_features + 1
+
     // RLS specific
     std::optional<double> forgetting_factor;   // Forgetting factor (0-1)
     std::optional<double> initial_p_diagonal;  // Initial P matrix diagonal value

--- a/src/table_functions/theil_sen_fit.cpp
+++ b/src/table_functions/theil_sen_fit.cpp
@@ -1,0 +1,290 @@
+#include <cmath>
+#include <vector>
+
+#include "duckdb.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+
+#include "../include/anofox_stats_ffi.h"
+#include "../include/ffi_enum_converters.hpp"
+#include "../include/map_options_parser.hpp"
+#include "telemetry.hpp"
+
+namespace duckdb {
+
+static LogicalType GetTheilSenResultType(bool compute_inference) {
+    child_list_t<LogicalType> children;
+
+    children.push_back(make_pair("coefficients", LogicalType::LIST(LogicalType::DOUBLE)));
+    children.push_back(make_pair("intercept", LogicalType::DOUBLE));
+    children.push_back(make_pair("r_squared", LogicalType::DOUBLE));
+    children.push_back(make_pair("adj_r_squared", LogicalType::DOUBLE));
+    children.push_back(make_pair("residual_std_error", LogicalType::DOUBLE));
+    children.push_back(make_pair("n_observations", LogicalType::BIGINT));
+    children.push_back(make_pair("n_features", LogicalType::BIGINT));
+
+    if (compute_inference) {
+        children.push_back(make_pair("std_errors", LogicalType::LIST(LogicalType::DOUBLE)));
+        children.push_back(make_pair("t_values", LogicalType::LIST(LogicalType::DOUBLE)));
+        children.push_back(make_pair("p_values", LogicalType::LIST(LogicalType::DOUBLE)));
+        children.push_back(make_pair("ci_lower", LogicalType::LIST(LogicalType::DOUBLE)));
+        children.push_back(make_pair("ci_upper", LogicalType::LIST(LogicalType::DOUBLE)));
+        children.push_back(make_pair("f_statistic", LogicalType::DOUBLE));
+        children.push_back(make_pair("f_pvalue", LogicalType::DOUBLE));
+    }
+
+    return LogicalType::STRUCT(std::move(children));
+}
+
+struct TheilSenFitBindData : public FunctionData {
+    bool fit_intercept = true;
+    bool compute_inference = false;
+    double confidence_level = 0.95;
+    uint32_t max_subpopulation = 10000;
+    uint32_t max_iterations = 300;
+    double tolerance = 1e-3;
+    uint64_t random_state = 0;
+    bool n_subsamples_set = false;
+    uint32_t n_subsamples_value = 0;
+
+    unique_ptr<FunctionData> Copy() const override {
+        auto result = make_uniq<TheilSenFitBindData>();
+        result->fit_intercept = fit_intercept;
+        result->compute_inference = compute_inference;
+        result->confidence_level = confidence_level;
+        result->max_subpopulation = max_subpopulation;
+        result->max_iterations = max_iterations;
+        result->tolerance = tolerance;
+        result->random_state = random_state;
+        result->n_subsamples_set = n_subsamples_set;
+        result->n_subsamples_value = n_subsamples_value;
+        return std::move(result);
+    }
+
+    bool Equals(const FunctionData &other_p) const override {
+        auto &o = other_p.Cast<TheilSenFitBindData>();
+        return fit_intercept == o.fit_intercept && compute_inference == o.compute_inference &&
+               confidence_level == o.confidence_level && max_subpopulation == o.max_subpopulation &&
+               max_iterations == o.max_iterations && tolerance == o.tolerance &&
+               random_state == o.random_state && n_subsamples_set == o.n_subsamples_set &&
+               n_subsamples_value == o.n_subsamples_value;
+    }
+};
+
+static unique_ptr<FunctionData> TheilSenFitBind(ClientContext &context, ScalarFunction &bound_function,
+                                                vector<unique_ptr<Expression>> &arguments) {
+    auto result = make_uniq<TheilSenFitBindData>();
+
+    if (arguments.size() >= 3 && arguments[2]->IsFoldable()) {
+        auto opts = RegressionMapOptions::ParseFromExpression(context, *arguments[2]);
+        if (opts.fit_intercept.has_value()) {
+            result->fit_intercept = opts.fit_intercept.value();
+        }
+        if (opts.compute_inference.has_value()) {
+            result->compute_inference = opts.compute_inference.value();
+        }
+        if (opts.confidence_level.has_value()) {
+            result->confidence_level = opts.confidence_level.value();
+        }
+        if (opts.max_subpopulation.has_value()) {
+            result->max_subpopulation = opts.max_subpopulation.value();
+        }
+        if (opts.max_iterations.has_value()) {
+            result->max_iterations = opts.max_iterations.value();
+        }
+        if (opts.tolerance.has_value()) {
+            result->tolerance = opts.tolerance.value();
+        }
+        if (opts.random_state.has_value()) {
+            result->random_state = opts.random_state.value();
+        }
+        if (opts.n_subsamples.has_value()) {
+            result->n_subsamples_set = true;
+            result->n_subsamples_value = opts.n_subsamples.value();
+        }
+    }
+
+    bound_function.return_type = GetTheilSenResultType(result->compute_inference);
+
+    PostHogTelemetry::Instance().CaptureFunctionExecution("theilsen_fit");
+    return std::move(result);
+}
+
+static vector<double> ExtractDoubleList(Vector &vec, idx_t row_idx) {
+    auto list_data = ListVector::GetData(vec);
+    auto &child = ListVector::GetEntry(vec);
+    auto child_data = FlatVector::GetData<double>(child);
+
+    vector<double> result;
+    auto offset = list_data[row_idx].offset;
+    auto length = list_data[row_idx].length;
+
+    for (idx_t i = 0; i < length; i++) {
+        result.push_back(child_data[offset + i]);
+    }
+
+    return result;
+}
+
+static void TheilSenFitFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+    auto &bind_data = state.expr.Cast<BoundFunctionExpression>().bind_info->Cast<TheilSenFitBindData>();
+
+    auto &y_vec = args.data[0];
+    auto &x_vec = args.data[1];
+
+    idx_t count = args.size();
+
+    for (idx_t row = 0; row < count; row++) {
+        vector<double> y_data = ExtractDoubleList(y_vec, row);
+
+        auto x_list_data = ListVector::GetData(x_vec);
+        auto &x_child = ListVector::GetEntry(x_vec);
+
+        vector<vector<double>> x_cols;
+        auto x_offset = x_list_data[row].offset;
+        auto x_length = x_list_data[row].length;
+
+        for (idx_t col = 0; col < x_length; col++) {
+            x_cols.push_back(ExtractDoubleList(x_child, x_offset + col));
+        }
+
+        AnofoxDataArray y_array;
+        y_array.data = y_data.data();
+        y_array.validity = nullptr;
+        y_array.len = y_data.size();
+
+        vector<AnofoxDataArray> x_arrays;
+        for (auto &col : x_cols) {
+            AnofoxDataArray arr;
+            arr.data = col.data();
+            arr.validity = nullptr;
+            arr.len = col.size();
+            x_arrays.push_back(arr);
+        }
+
+        AnofoxTheilSenOptions options;
+        options.fit_intercept = bind_data.fit_intercept;
+        options.compute_inference = bind_data.compute_inference;
+        options.confidence_level = bind_data.confidence_level;
+        options.max_subpopulation = bind_data.max_subpopulation;
+        options.max_iterations = bind_data.max_iterations;
+        options.tolerance = bind_data.tolerance;
+        options.random_state = bind_data.random_state;
+        options.n_subsamples_set = bind_data.n_subsamples_set;
+        options.n_subsamples_value = bind_data.n_subsamples_value;
+
+        AnofoxFitResultCore core_result;
+        AnofoxFitResultInference inference_result;
+        AnofoxError error;
+
+        bool success = anofox_theilsen_fit(y_array, x_arrays.data(), x_arrays.size(), options, &core_result,
+                                           bind_data.compute_inference ? &inference_result : nullptr, &error);
+
+        if (!success) {
+            throw InvalidInputException("Theil-Sen fit failed: " + string(error.message));
+        }
+
+        auto &struct_vec = StructVector::GetEntries(result);
+        idx_t struct_idx = 0;
+
+        auto &coef_list = *struct_vec[struct_idx++];
+        auto &coef_child = ListVector::GetEntry(coef_list);
+        auto coef_offset = ListVector::GetListSize(coef_list);
+        ListVector::SetListSize(coef_list, coef_offset + core_result.coefficients_len);
+        auto coef_data = FlatVector::GetData<double>(coef_child);
+        for (size_t i = 0; i < core_result.coefficients_len; i++) {
+            coef_data[coef_offset + i] = core_result.coefficients[i];
+        }
+        ListVector::GetData(coef_list)[row] = {coef_offset, core_result.coefficients_len};
+
+        FlatVector::GetData<double>(*struct_vec[struct_idx++])[row] = core_result.intercept;
+        FlatVector::GetData<double>(*struct_vec[struct_idx++])[row] = core_result.r_squared;
+        FlatVector::GetData<double>(*struct_vec[struct_idx++])[row] = core_result.adj_r_squared;
+        FlatVector::GetData<double>(*struct_vec[struct_idx++])[row] = core_result.residual_std_error;
+        FlatVector::GetData<int64_t>(*struct_vec[struct_idx++])[row] = core_result.n_observations;
+        FlatVector::GetData<int64_t>(*struct_vec[struct_idx++])[row] = core_result.n_features;
+
+        if (bind_data.compute_inference) {
+            auto set_list = [&](Vector &list_vec, double *data, size_t len) {
+                auto &child = ListVector::GetEntry(list_vec);
+                auto offset = ListVector::GetListSize(list_vec);
+                ListVector::SetListSize(list_vec, offset + len);
+                auto vec_data = FlatVector::GetData<double>(child);
+                for (size_t i = 0; i < len; i++) {
+                    vec_data[offset + i] = data[i];
+                }
+                ListVector::GetData(list_vec)[row] = {offset, len};
+            };
+
+            set_list(*struct_vec[struct_idx++], inference_result.std_errors, inference_result.len);
+            set_list(*struct_vec[struct_idx++], inference_result.t_values, inference_result.len);
+            set_list(*struct_vec[struct_idx++], inference_result.p_values, inference_result.len);
+            set_list(*struct_vec[struct_idx++], inference_result.ci_lower, inference_result.len);
+            set_list(*struct_vec[struct_idx++], inference_result.ci_upper, inference_result.len);
+
+            FlatVector::GetData<double>(*struct_vec[struct_idx++])[row] = inference_result.f_statistic;
+            FlatVector::GetData<double>(*struct_vec[struct_idx++])[row] = inference_result.f_pvalue;
+
+            anofox_free_result_inference(&inference_result);
+        }
+
+        anofox_free_result_core(&core_result);
+    }
+
+    result.SetVectorType(VectorType::FLAT_VECTOR);
+}
+
+void RegisterTheilSenFitFunction(ExtensionLoader &loader) {
+    ScalarFunction basic_func(
+        {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
+        LogicalType::ANY, TheilSenFitFunction, TheilSenFitBind);
+
+    ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
+                             LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::ANY},
+                            LogicalType::ANY, TheilSenFitFunction, TheilSenFitBind);
+
+    {
+        ScalarFunctionSet func_set("anofox_stats_theilsen_fit");
+        func_set.AddFunction(basic_func);
+        func_set.AddFunction(map_func);
+        CreateScalarFunctionInfo info(std::move(func_set));
+        info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+
+        FunctionDescription d1;
+        d1.description = "Fits a Theil-Sen robust regression model. Returns coefficients and fit statistics as a "
+                         "struct.";
+        d1.examples = {"anofox_stats_theilsen_fit(y, x)"};
+        d1.categories = {"regression"};
+        d1.parameter_names = {"y", "x"};
+        d1.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE),
+                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))};
+        info.descriptions.push_back(std::move(d1));
+
+        FunctionDescription d2;
+        d2.description = "Fits a Theil-Sen regression model with optional MAP of settings (max_subpopulation, "
+                         "n_subsamples, max_iterations, tolerance, random_state, fit_intercept, "
+                         "compute_inference, confidence_level).";
+        d2.examples = {"anofox_stats_theilsen_fit(y, x, {'random_state': 42, 'max_subpopulation': 5000})"};
+        d2.categories = {"regression"};
+        d2.parameter_names = {"y", "x", "options"};
+        d2.parameter_types = {LogicalType::LIST(LogicalType::DOUBLE),
+                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::ANY};
+        info.descriptions.push_back(std::move(d2));
+
+        loader.RegisterFunction(std::move(info));
+    }
+    {
+        ScalarFunctionSet alias_set("theilsen_fit");
+        alias_set.AddFunction(basic_func);
+        alias_set.AddFunction(map_func);
+        CreateScalarFunctionInfo alias_info(std::move(alias_set));
+        alias_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
+        alias_info.alias_of = "anofox_stats_theilsen_fit";
+        loader.RegisterFunction(std::move(alias_info));
+    }
+}
+
+} // namespace duckdb


### PR DESCRIPTION
Layer 3 of the Theil-Sen chain. Stacked on #80.

Mirrors the RANSAC layer-3 PR (#76) minus the consensus-set extras (Theil-Sen has no inlier mask / trial count to surface).

## What this delivers
- \`src/aggregate_functions/theil_sen_aggregate.cpp\` (~440 LOC).
- \`src/table_functions/theil_sen_fit.cpp\` (~290 LOC).
- Forward declarations + registration + CMakeLists.
- New \`max_subpopulation\` / \`n_subsamples\` keys in \`RegressionMapOptions\`.

## Surface
\`\`\`sql
SELECT * FROM theilsen_fit(y_list, x_matrix, {'random_state': 42, 'max_subpopulation': 5000});
SELECT (theilsen_fit_agg(y, [x1, x2])).coefficients[1] AS slope FROM t GROUP BY g;
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)