### PR TITLE
Make deploy resilient to flaky Windows builds

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -30,11 +30,17 @@ jobs:
   duckdb-stable-deploy:
     name: Deploy extension binaries (v1.5.3)
     needs: duckdb-stable-build
+    # Run the deploy step even when a non-essential build matrix entry
+    # (currently windows_amd64 — DuckDB's vendored third_party/fmt is
+    # flaky on MSVC) fails. The deploy job itself fans out per arch and
+    # only pushes the artifacts that actually exist.
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
       duckdb_version: v1.5.3
       extension_name: anofox_statistics
+      exclude_archs: "windows_amd64"
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 
@@ -51,11 +57,15 @@ jobs:
   duckdb-v144-deploy:
     name: Deploy extension binaries (v1.4.4 LTS)
     needs: duckdb-v144-build
+    # Same resilience as the v1.5.3 deploy: don't gate the whole release on
+    # the flaky LTS windows_amd64_mingw matrix entry.
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/_extension_deploy.yml
     secrets: inherit
     with:
       duckdb_version: v1.4.4
       extension_name: anofox_statistics
+      exclude_archs: "windows_amd64_mingw"
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
## Why

\`INSTALL 'anofox_statistics' FROM 'http://get.erpl.io'\` is failing because the Linux artifact for the latest commits hasn't been published. The deploy job is gated on \`needs: duckdb-stable-build\`, and that build's MSVC matrix entry has been flaky against DuckDB's vendored \`third_party/fmt/format.h\` — error in the upstream \`fmt\` lib, not our code. When MSVC fails the whole build job fails closed and skips the deploy, even though Linux / macOS / wasm all build green.

## Changes

\`MainDistributionPipeline.yml\`:
- \`if: \${{ !cancelled() }}\` on both deploy jobs so they run when builds complete (regardless of individual matrix entry outcomes), but still respect explicit workflow cancellation.
- \`exclude_archs\` drops the flaky Windows architectures from the deploy matrix:
  - v1.5.3 → exclude \`windows_amd64\` (MSVC, \`fmt/format.h\` issue)
  - v1.4.4 → exclude \`windows_amd64_mingw\` (MinGW, pre-existing LTS noise)

## After this lands
- Push triggers main pipeline.
- Build matrix runs; Windows entries may still fail.
- Deploy fans out per-arch and pushes Linux/macOS/wasm artifacts.
- \`INSTALL ... FROM 'http://get.erpl.io'\` picks them up on a Linux dev box.

When the upstream DuckDB/fmt issue clears, removing the exclusions is a one-line revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)