### PR TITLE
Make deploy matrix tolerant to single-arch failures

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -40,7 +40,7 @@ jobs:
     with:
       duckdb_version: v1.5.3
       extension_name: anofox_statistics
-      exclude_archs: "windows_amd64"
+      exclude_archs: "windows_amd64;windows_amd64_mingw"
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 
@@ -65,7 +65,7 @@ jobs:
     with:
       duckdb_version: v1.4.4
       extension_name: anofox_statistics
-      exclude_archs: "windows_amd64_mingw"
+      exclude_archs: "windows_amd64;windows_amd64_mingw"
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -91,6 +91,10 @@ jobs:
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.deploy_matrix != '{}' && needs.generate_matrix.outputs.deploy_matrix != '' }}
     strategy:
+      # One missing artifact (e.g. a Windows build that didn't produce one)
+      # must not cancel sibling per-arch deploys — Linux / macOS / wasm
+      # publishing should proceed independently.
+      fail-fast: false
       matrix: ${{fromJson(needs.generate_matrix.outputs.deploy_matrix)}}
 
     steps:


### PR DESCRIPTION
Follow-up to #84. The previous fix excluded one Windows arch per deploy but missed that BOTH duckdb_version paths build BOTH Windows targets (MSVC + MinGW). The still-included one had no artifact (because its build failed), and fail-fast on the deploy matrix then cancelled every sibling per-arch deploy (Linux/macOS/wasm). Net effect: nothing got pushed to S3.

## Changes

\`_extension_deploy.yml\`:
- \`fail-fast: false\` on the deploy matrix.

\`MainDistributionPipeline.yml\`:
- \`exclude_archs\` now drops both \`windows_amd64\` and \`windows_amd64_mingw\` from both deploys.

## After this lands
- Build runs (Windows entries still may fail).
- Deploy runs and per-arch deploys for Linux / macOS / wasm proceed independently — no fail-fast cascade.
- Linux artifact for v1.5.3 lands on get.erpl.io.
- \`INSTALL 'anofox_statistics' FROM 'http://get.erpl.io'\` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)