### PR TITLE
Fix double-signature in extension-upload.sh

### DIFF
--- a/scripts/extension-upload.sh
+++ b/scripts/extension-upload.sh
@@ -23,8 +23,19 @@ echo $ext
 
 script_dir="$(dirname "$(readlink -f "$0")")"
 
-# calculate SHA256 hash of extension binary
+# The build artifact already ends with a 256-byte signature placeholder
+# (zero-filled when unsigned). Strip it before computing the hash and
+# re-appending a fresh signature — otherwise we'd end up with 512 bytes
+# of trailing data and the metadata footer would no longer be at the
+# fixed offset DuckDB v1.5.3+ checks, causing the install to fail with
+# "metadata at the end of the file is invalid".
+#
+# wasm artifacts do not carry the placeholder, so the strip is gated on
+# the native-binary path only.
 cat $ext > $ext.append
+if [[ $4 != wasm* ]]; then
+  truncate -s -256 $ext.append
+fi
 
 if [[ $4 == wasm* ]]; then
   # 0 for custom section


### PR DESCRIPTION
## Root cause

\`INSTALL 'anofox_statistics' FROM 'http://get.erpl.io'\` was failing on DuckDB v1.5.3 with:

> The file is not a DuckDB extension. The metadata at the end of the file is invalid

The deployed binary on S3 had 672 bytes of trailing data after the CPP metadata block, where DuckDB expects exactly 416 (160 bytes metadata + 256 bytes signature).

The CMake build already appends a 256-byte signature placeholder to the artifact (\`/tmp/extension/<name>.duckdb_extension\` ends with 256 zero bytes when unsigned). \`scripts/extension-upload.sh\` was unconditionally appending **another** 256-byte placeholder, doubling the trailing zeros and shifting the metadata footer out of the offset DuckDB checks.

Confirmed by diffing the deployed binary against a known-good extension (\`extensions.duckdb.org/v1.5.3/linux_amd64/fts.duckdb_extension.gz\`): same metadata block, but ours has an extra 256 bytes of zeros between the metadata and the signature.

## Fix
Strip the placeholder before re-appending the signature on the native path. Wasm artifacts are not affected (the script builds the wasm custom-section wrapper for them rather than relying on an inline placeholder).

## After this lands
The next push to \`main\` triggers a deploy. The new \`v1.5.3 / linux_amd64\` artifact will have the canonical 416-byte trailer, and \`INSTALL 'anofox_statistics' FROM 'http://get.erpl.io'; LOAD 'anofox_statistics'\` should expose the full Huber + RANSAC + Theil-Sen SQL surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)