### PR TITLE
Fix osx_arm64 flake in test_fit_predict_by (TEST 53 tolerance)

### DIFF
--- a/test/sql/macros/test_fit_predict_by.test
+++ b/test/sql/macros/test_fit_predict_by.test
@@ -564,9 +564,12 @@ FROM ols_fit_predict_by('split_data', group_id, y, [x1, x2], split := split);
 10	2
 
 # TEST 53: Split results match NULL-y approach (same predictions per group)
+# split vs non-split run the identical solver on the same rows; any difference
+# is pure floating-point summation order (observed flaking on osx_arm64), so
+# compare with a magnitude-scaled relative tolerance rather than a tight 1e-4.
 query I
 SELECT COUNT(*) FROM (
-    SELECT a.group_id, ABS(a.sum_yhat - b.sum_yhat) < 1e-4 AS match
+    SELECT a.group_id, ABS(a.sum_yhat - b.sum_yhat) <= 1e-3 * GREATEST(ABS(a.sum_yhat), ABS(b.sum_yhat), 1.0) AS match
     FROM (SELECT group_id, SUM(yhat) AS sum_yhat FROM ols_fit_predict_by('reg_data', group_id, y, [x1, x2]) GROUP BY group_id) a
     JOIN (SELECT group_id, SUM(yhat) AS sum_yhat FROM ols_fit_predict_by('split_data', group_id, y, [x1, x2], split := split) GROUP BY group_id) b
     ON a.group_id = b.group_id


### PR DESCRIPTION
## What

Loosen TEST 53 in `test/sql/macros/test_fit_predict_by.test` from a tight `1e-4` absolute bound to a magnitude-scaled relative tolerance.

## Why

TEST 53 compares per-group `SUM(yhat)` between split and non-split `ols_fit_predict_by`. Both run the identical solver on the same training rows, so any difference is pure floating-point summation order. This flaked deterministically on `osx_arm64` (observed on the GLM PRs #89/#91 and on a #90 push run — the *same commit* passed macOS in one run and failed in another), while passing on Linux/macOS-x64.

The Windows side of the CI breakage was already addressed on `main` by #94 (DuckDB v1.5.4 / v1.4.5 LTS bump). This is the remaining piece so the shared regression test stops flaking across all branches.

## Verification

`./build/release/test/unittest test/sql/macros/test_fit_predict_by.test` → all 83 assertions pass. The new bound is strictly looser than the old one for any non-trivial value, so it also clears on osx_arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)