### PR TITLE
deps: bump posthog-telemetry to 4cd2256 (teardown SIGSEGV fix)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,13 @@ if(ANOFOX_TELEMETRY_ENABLED)
 
     target_compile_definitions(${EXTENSION_NAME} PRIVATE ANOFOX_TELEMETRY_ENABLED)
     target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE ANOFOX_TELEMETRY_ENABLED)
+else()
+    # Since posthog-telemetry consolidated on main (DataZooDE/posthog-telemetry#5),
+    # the header's no-op stubs are opt-out: POSTHOG_TELEMETRY_DISABLED turns every
+    # telemetry call into an inline no-op (the old header keyed on the absence of
+    # ANOFOX_TELEMETRY_ENABLED instead).
+    target_compile_definitions(${EXTENSION_NAME} PRIVATE POSTHOG_TELEMETRY_DISABLED)
+    target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE POSTHOG_TELEMETRY_DISABLED)
 endif()
 
 # Link Windows system libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,13 @@ if(ANOFOX_TELEMETRY_ENABLED)
 
     target_compile_definitions(${EXTENSION_NAME} PRIVATE ANOFOX_TELEMETRY_ENABLED)
     target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE ANOFOX_TELEMETRY_ENABLED)
+
+    # posthog-telemetry reads the machine id from the IORegistry on macOS
+    # (IORegistryEntryFromPath et al.), which requires linking IOKit explicitly.
+    if(APPLE)
+        target_link_libraries(${EXTENSION_NAME} "-framework IOKit" "-framework CoreFoundation")
+        target_link_libraries(${LOADABLE_EXTENSION_NAME} "-framework IOKit" "-framework CoreFoundation")
+    endif()
 else()
     # Since posthog-telemetry consolidated on main (DataZooDE/posthog-telemetry#5),
     # the header's no-op stubs are opt-out: POSTHOG_TELEMETRY_DISABLED turns every


### PR DESCRIPTION
Bumps the shared `posthog-telemetry` submodule from `0433745` to `4cd2256` (current posthog-telemetry main).

## Why

`0433745` can SIGSEGV at process exit: its atexit shutdown handler **drains** the telemetry queue, constructing new httplib `Client`s whose URL-parsing regex — a function-local static already destroyed at that point — gets dereferenced dead. Reproduced deterministically in quack-oauth (DuckDB v1.5.3 statically-linked unittest binary, exit 139 after all tests pass; gdb stack in DataZooDE/posthog-telemetry#4). The same mechanism fires in any consumer with telemetry events still queued at exit.

## New pin

DataZooDE/posthog-telemetry#4: `Stop()` discards pending tasks (no new network I/O once shutdown begins) and `Instance()` pre-warms httplib's function-local statics before registering the atexit handler.

## Verification

- posthog-telemetry suite: 64/64 tests green on Linux/macOS/Windows CI
- End-to-end in quack-oauth: test suite went from exit 139 on every run to exit 0 on 5/5 runs (DataZooDE/quack-oauth#8, full distribution matrix green, merged)

Part of the portfolio-wide sweep after DataZooDE/quack-oauth#8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785748267&installation_id=142929061&pr_number=101&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F101&signature=58c5110944a20e58125475698e5c0e1a4e0aaf4a75cb5f48439f3326b948f977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->