### PR TITLE
fix: link Rust FFI archive into WASM build (#102)

### DIFF
--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -1,2 +1,18 @@
 #This file is included by DuckDB's build system. It specifies which extension to load.
-duckdb_extension_load(anofox_statistics SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR} LOAD_TESTS)
+duckdb_extension_load(anofox_statistics
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
+    LOAD_TESTS
+    # On WASM builds the extension target is a STATIC library and the final
+    # link happens in a post-build emcc step (extension_build_tools.cmake:196)
+    # that reads its extra archives from DUCKDB_EXTENSION_ANOFOX_STATISTICS_LINKED_LIBS.
+    # Without this, the Rust FFI static archive (target: anofox_stats_ffi, defined
+    # in CMakeLists.txt via corrosion_import_crate) is never linked into the .wasm,
+    # so all C-linkage FFI symbols end up as unresolvable imports and LOAD fails
+    # with "TypeError: r is not a function" in DuckDB-Wasm (issue #102, upstream
+    # duckdb/duckdb#23740, sister-extension fix DataZooDE/anofox-forecast#240).
+    # Corrosion registers two targets: `anofox_stats_ffi` (INTERFACE — for
+    # `target_link_libraries`) and `anofox_stats_ffi-static` (the actual STATIC
+    # IMPORTED archive). We need the -static suffix here so TARGET_FILE
+    # resolves to the .a file path.
+    LINKED_LIBS "$<TARGET_FILE:anofox_stats_ffi-static>"
+)


### PR DESCRIPTION
Closes #102.

## Summary

The WASM build was missing the entire Rust FFI surface (`anofox_stats_ffi` symbols), causing `LOAD anofox_statistics` to throw \`TypeError: r is not a function\` at first use in DuckDB-Wasm.

Identical trap to the one just fixed in the sister extension at [DataZooDE/anofox-forecast#240](https://github.com/DataZooDE/anofox-forecast/pull/240); upstream tracking issue at [duckdb/duckdb#23740](https://github.com/duckdb/duckdb/issues/23740).

## Root cause

On EMSCRIPTEN, DuckDB's `build_loadable_extension_directory` creates the extension target as a **STATIC** library (\`extension_build_tools.cmake:116\`) and defers the final link to a post-build \`emcc -sSIDE_MODULE=2\` step. That step reads its additional archives from \`DUCKDB_EXTENSION_ANOFOX_STATISTICS_LINKED_LIBS\`, populated exclusively by the \`LINKED_LIBS\` parameter of \`duckdb_extension_load()\`. We never passed it.

On Linux/macOS/Windows this doesn't manifest because the extension is built as a **SHARED** library and \`target_link_libraries(<TARGET> anofox_stats_ffi-static)\` in \`CMakeLists.txt\` pulls in \`libanofox_stats_ffi.a\` at the shared-library link step. On WASM, \`target_link_libraries\` on a STATIC target only records an interface dependency — the emcc post-build never sees the Rust archive, and every C-linkage FFI symbol ends up as an unresolvable dylink import.

## Fix

One line in \`extension_config.cmake\`:

\`\`\`diff
 duckdb_extension_load(anofox_statistics
     SOURCE_DIR \${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
+    LINKED_LIBS \"\$<TARGET_FILE:anofox_stats_ffi-static>\"
 )
\`\`\`

Corrosion registers two targets: \`anofox_stats_ffi\` (INTERFACE — for \`target_link_libraries\`) and \`anofox_stats_ffi-static\` (the actual STATIC IMPORTED archive). The \`-static\` suffix is required so \`\$<TARGET_FILE:...>\` resolves to the \`.a\` file path.

## Non-WASM impact

\`LINKED_LIBS\` is only consumed inside the \`if(EMSCRIPTEN)\` branch of \`build_loadable_extension_directory\` (\`extension_build_tools.cmake:183-198\`). On Linux/macOS/Windows the variable is set but never read — no behavioural change to native builds.

## Verification

The identical fix was verified end-to-end on the sister anofox-forecast extension via a local WASM rebuild (emsdk 3.1.71):

| Property | Before | After |
|---|---|---|
| \`.wasm\` size | 1.77 MB | 3.92 MB |
| Unresolved \`anofox_*\` FFI imports | **84** | **0** |
| Rust code embedded (trait vtables, type names, panic strings from \`src/models/*\`) | absent | present |

Same mechanism, same crate layout (corrosion → \`<crate>-static\` STATIC IMPORTED), same expected outcome here.

## Test plan

- [ ] CI green across wasm_mvp / wasm_eh / wasm_threads.
- [ ] Optional: after merge, a WASM CI artifact end-to-end \`INSTALL anofox_statistics FROM community; LOAD; SELECT …;\` in DuckDB-Wasm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786223934&installation_id=142929061&pr_number=103&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F103&signature=dfebe0da2c4256387d6cabd0d11174c89d11f699f3f94b687bfd7d0575ddb886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->