### PR TITLE
feat(telemetry): adopt schema-2 telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ Thumbs.db
 
 # Debug files
 *.dSYM/
+
+.cache/

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,80 @@
+# Anofox Statistics Telemetry
+
+The `anofox_statistics` DuckDB extension collects **anonymous, privacy-preserving
+usage telemetry** so we can see which statistical functions are used, on which
+platforms, and where they fail — and prioritise accordingly. It is **on by
+default** and **trivial to turn off**.
+
+Telemetry is emitted through the shared
+[`DataZooDE/posthog-telemetry`](https://github.com/DataZooDE/posthog-telemetry)
+library and follows the cross-product **`telemetry_schema: 2`** envelope
+(`posthog-telemetry/TELEMETRY-SCHEMA.md`). Ingestion is the EU PostHog cloud.
+Telemetry is compiled in only when the extension is built with
+`ANOFOX_TELEMETRY_ENABLED`; otherwise every call site is a no-op stub.
+
+## How to turn it off
+
+Any one of these fully short-circuits telemetry — when disabled, **nothing
+leaves the machine** (the opt-out is enforced at the transport, not just at the
+call sites):
+
+```sql
+SET anofox_telemetry_enabled = false;   -- DuckDB setting (per session)
+```
+
+```bash
+export DATAZOO_DISABLE_TELEMETRY=1       # environment (1|true|yes)
+```
+
+## The guarantee: bounded, enumerated, non-PII
+
+Every property we send is **either** a constant drawn from a small,
+code-controlled enumeration **or** a pure number (durations, counts). The
+library additionally clamps every outgoing string to 512 bytes as a backstop.
+
+We **never** send: table names, column names, `FILTER`/`WHERE` clauses, SQL
+text, row/result data, model coefficients, input values, or error messages. The
+only free-form-looking strings sent are **function names**, and those are drawn
+from the fixed set of functions this extension registers — not from user data.
+
+## What is collected
+
+### Envelope (attached to every event)
+
+`product` (`anofox_statistics`), `product_version`, `product_edition` (`oss`),
+`telemetry_schema` (`2`), `duckdb_version`, `os`, `arch`, `platform`, `is_ci`,
+`is_container`, a per-process `$session_id`, and — once associated — the
+`deployment` group. `distinct_id` is the SHA-256 of a machine id: a **stable,
+pseudonymous** identifier, not tied to any personal data.
+
+### Events
+
+| Event | When | Properties (beyond the envelope) |
+|---|---|---|
+| `extension_loaded` | the `anofox_statistics` extension loads | — |
+| `function_executed` | a DuckDB function runs — **aggregated** per function per session (not per row) | `function_name`, `call_count`, `duration_ms_p50` |
+
+That is the complete set of events emitted by this repository today. The shared
+schema also defines `feature_used` (`CaptureFeature`) and `$exception`
+(`CaptureError`), but `anofox_statistics` does **not** emit them yet — that is a
+later, per-repo instrumentation pass.
+
+## Function-call aggregation
+
+DuckDB function calls are recorded via `RecordFunctionCall(function_name)`, which
+aggregates in-process into a single `function_executed` event per function per
+session (carrying `call_count` and `duration_ms_p50`), flushed at session end.
+
+The instrumented functions are the extension's statistical routines — regression
+fits (`ols_fit`, `ridge_fit`, `elasticnet_fit`, `wls_fit`, `rls_fit`, …), their
+aggregate/window forms (`ols_fit_agg`, `ols_fit_predict`, …), hypothesis tests
+(`t_test`, `mann_whitney`, `kruskal_wallis`, `shapiro_wilk`, …), and diagnostics
+(`aic`, `bic`, `vif`, `jarque_bera`, …). Each `RecordFunctionCall` sits at the
+function's bind/registration step or at the top of the per-chunk execute path —
+**never inside a per-row loop** — so a million-row scan produces O(1) telemetry
+rows, not a firehose.
+
+## Enterprise / account analytics
+
+`anofox_statistics` is OSS and associates only the `deployment` group. It has no
+license key, so no `account` group is associated.

--- a/src/aggregate_functions/aid_aggregate.cpp
+++ b/src/aggregate_functions/aid_aggregate.cpp
@@ -339,7 +339,7 @@ static unique_ptr<FunctionData> AidAggBind(ClientContext &context, AggregateFunc
 
     function.return_type = GetAidAggResultType();
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("aid_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("aid_agg");
     return std::move(result);
 }
 
@@ -361,7 +361,7 @@ static unique_ptr<FunctionData> AidAnomalyAggBind(ClientContext &context, Aggreg
 
     function.return_type = GetAidAnomalyResultType();
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("aid_anomaly_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("aid_anomaly_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/alm_aggregate.cpp
+++ b/src/aggregate_functions/alm_aggregate.cpp
@@ -389,7 +389,7 @@ static unique_ptr<FunctionData> AlmAggBind(ClientContext &context, AggregateFunc
 
     function.return_type = GetAlmAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("alm_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("alm_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/alm_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/alm_fit_predict_aggregate.cpp
@@ -487,7 +487,7 @@ static unique_ptr<FunctionData> AlmFitPredictAggBind(ClientContext &context, Agg
     }
 
     function.return_type = GetAlmFitPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("alm_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("alm_fit_predict_agg");
     return std::move(result);
 }
 
@@ -528,7 +528,7 @@ static unique_ptr<FunctionData> AlmFitPredictAggBindWithSplit(ClientContext &con
     }
 
     function.return_type = GetAlmFitPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("alm_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("alm_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/anova_aggregate.cpp
+++ b/src/aggregate_functions/anova_aggregate.cpp
@@ -188,7 +188,7 @@ static void AnovaAggFinalize(Vector &state_vector, AggregateInputData &aggr_inpu
 static unique_ptr<FunctionData> AnovaAggBind(ClientContext &context, AggregateFunction &function,
                                               vector<unique_ptr<Expression>> &arguments) {
     function.return_type = GetAnovaAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("one_way_anova_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("one_way_anova_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/binom_test_aggregate.cpp
+++ b/src/aggregate_functions/binom_test_aggregate.cpp
@@ -221,7 +221,7 @@ static unique_ptr<FunctionData> BinomTestAggBind(ClientContext &context, Aggrega
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("binom_test_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("binom_test_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/binomial_aggregate.cpp
+++ b/src/aggregate_functions/binomial_aggregate.cpp
@@ -358,7 +358,7 @@ static unique_ptr<FunctionData> BinomialAggBind(ClientContext &context, Aggregat
 
     function.return_type = GetBinomialAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("binomial_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("binomial_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/bls_aggregate.cpp
+++ b/src/aggregate_functions/bls_aggregate.cpp
@@ -362,7 +362,7 @@ static unique_ptr<FunctionData> BlsAggBind(ClientContext &context, AggregateFunc
 
     function.return_type = GetBlsAggResultType();
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("bls_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("bls_fit_agg");
     return std::move(result);
 }
 
@@ -391,7 +391,7 @@ static unique_ptr<FunctionData> NnlsAggBind(ClientContext &context, AggregateFun
 
     function.return_type = GetBlsAggResultType();
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("nnls_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("nnls_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/bls_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/bls_fit_predict_aggregate.cpp
@@ -487,7 +487,7 @@ static unique_ptr<FunctionData> BlsFitPredictAggBind(ClientContext &context, Agg
     }
 
     function.return_type = GetBlsFitPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("bls_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("bls_fit_predict_agg");
     return std::move(result);
 }
 
@@ -524,7 +524,7 @@ static unique_ptr<FunctionData> BlsFitPredictAggBindWithSplit(ClientContext &con
     }
 
     function.return_type = GetBlsFitPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("bls_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("bls_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/brown_forsythe_aggregate.cpp
+++ b/src/aggregate_functions/brown_forsythe_aggregate.cpp
@@ -198,7 +198,7 @@ static void BrownForsytheAggFinalize(Vector &state_vector, AggregateInputData &a
 static unique_ptr<FunctionData> BrownForsytheAggBind(ClientContext &context, AggregateFunction &function,
                                                        vector<unique_ptr<Expression>> &arguments) {
     function.return_type = GetBrownForsytheAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("brown_forsythe_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("brown_forsythe_agg");
     return make_uniq<BrownForsytheBindData>();
 }
 

--- a/src/aggregate_functions/brunner_munzel_aggregate.cpp
+++ b/src/aggregate_functions/brunner_munzel_aggregate.cpp
@@ -233,7 +233,7 @@ static unique_ptr<FunctionData> BrunnerMunzelAggBind(ClientContext &context, Agg
         bind_data->options = BrunnerMunzelMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("brunner_munzel_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("brunner_munzel_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/chisq_aggregate.cpp
+++ b/src/aggregate_functions/chisq_aggregate.cpp
@@ -206,7 +206,7 @@ static unique_ptr<FunctionData> ChiSquareAggBind(ClientContext &context, Aggrega
         bind_data->options = ChiSquareMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("chisq_test_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("chisq_test_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/chisq_gof_aggregate.cpp
+++ b/src/aggregate_functions/chisq_gof_aggregate.cpp
@@ -173,7 +173,7 @@ static void ChisqGofAggFinalize(Vector &state_vector, AggregateInputData &aggr_i
 static unique_ptr<FunctionData> ChisqGofAggBind(ClientContext &context, AggregateFunction &function,
                                                  vector<unique_ptr<Expression>> &arguments) {
     function.return_type = GetChisqGofAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("chisq_gof_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("chisq_gof_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/clark_west_aggregate.cpp
+++ b/src/aggregate_functions/clark_west_aggregate.cpp
@@ -243,7 +243,7 @@ static unique_ptr<FunctionData> ClarkWestAggBind(ClientContext &context, Aggrega
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("clark_west_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("clark_west_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/cohen_kappa_aggregate.cpp
+++ b/src/aggregate_functions/cohen_kappa_aggregate.cpp
@@ -241,7 +241,7 @@ static unique_ptr<FunctionData> CohenKappaAggBind(ClientContext &context, Aggreg
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("cohen_kappa_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("cohen_kappa_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/contingency_coef_aggregate.cpp
+++ b/src/aggregate_functions/contingency_coef_aggregate.cpp
@@ -175,7 +175,7 @@ static void ContingencyCoefAggFinalize(Vector &state_vector, AggregateInputData 
 static unique_ptr<FunctionData> ContingencyCoefAggBind(ClientContext &context, AggregateFunction &function,
                                                         vector<unique_ptr<Expression>> &arguments) {
     function.return_type = LogicalType::DOUBLE;
-    PostHogTelemetry::Instance().CaptureFunctionExecution("contingency_coef_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("contingency_coef_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/cramers_v_aggregate.cpp
+++ b/src/aggregate_functions/cramers_v_aggregate.cpp
@@ -183,7 +183,7 @@ static void CramersVAggFinalize(Vector &state_vector, AggregateInputData &aggr_i
 static unique_ptr<FunctionData> CramersVAggBind(ClientContext &context, AggregateFunction &function,
                                                  vector<unique_ptr<Expression>> &arguments) {
     function.return_type = GetCramersVAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("cramers_v_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("cramers_v_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/dagostino_k2_aggregate.cpp
+++ b/src/aggregate_functions/dagostino_k2_aggregate.cpp
@@ -165,7 +165,7 @@ static void DAgostinoK2AggFinalize(Vector &state_vector, AggregateInputData &agg
 static unique_ptr<FunctionData> DAgostinoK2AggBind(ClientContext &context, AggregateFunction &function,
                                                     vector<unique_ptr<Expression>> &arguments) {
     function.return_type = GetDAgostinoK2AggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("dagostino_k2_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("dagostino_k2_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/diebold_mariano_aggregate.cpp
+++ b/src/aggregate_functions/diebold_mariano_aggregate.cpp
@@ -273,7 +273,7 @@ static unique_ptr<FunctionData> DieboldMarianoAggBind(ClientContext &context, Ag
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("diebold_mariano_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("diebold_mariano_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/distance_cor_aggregate.cpp
+++ b/src/aggregate_functions/distance_cor_aggregate.cpp
@@ -237,7 +237,7 @@ static unique_ptr<FunctionData> DistanceCorAggBind(ClientContext &context, Aggre
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("distance_cor_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("distance_cor_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/elasticnet_aggregate.cpp
+++ b/src/aggregate_functions/elasticnet_aggregate.cpp
@@ -351,7 +351,7 @@ static unique_ptr<FunctionData> ElasticNetAggBind(ClientContext &context, Aggreg
     // Set return type
     function.return_type = GetElasticNetAggResultType();
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("elasticnet_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("elasticnet_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/elasticnet_predict_aggregate.cpp
+++ b/src/aggregate_functions/elasticnet_predict_aggregate.cpp
@@ -432,7 +432,7 @@ static unique_ptr<FunctionData> ElasticNetPredictAggBind(ClientContext &context,
     }
 
     function.return_type = GetElasticNetPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("elasticnet_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("elasticnet_fit_predict_agg");
     return std::move(result);
 }
 
@@ -470,7 +470,7 @@ static unique_ptr<FunctionData> ElasticNetPredictAggBindWithSplit(ClientContext 
     }
 
     function.return_type = GetElasticNetPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("elasticnet_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("elasticnet_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/energy_distance_aggregate.cpp
+++ b/src/aggregate_functions/energy_distance_aggregate.cpp
@@ -221,7 +221,7 @@ static unique_ptr<FunctionData> EnergyDistanceAggBind(ClientContext &context, Ag
         bind_data->options = EnergyDistanceMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("energy_distance_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("energy_distance_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/fisher_exact_aggregate.cpp
+++ b/src/aggregate_functions/fisher_exact_aggregate.cpp
@@ -223,7 +223,7 @@ static unique_ptr<FunctionData> FisherExactAggBind(ClientContext &context, Aggre
         bind_data->options = FisherExactMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("fisher_exact_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("fisher_exact_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/g_test_aggregate.cpp
+++ b/src/aggregate_functions/g_test_aggregate.cpp
@@ -199,7 +199,7 @@ static void GTestAggFinalize(Vector &state_vector, AggregateInputData &aggr_inpu
 static unique_ptr<FunctionData> GTestAggBind(ClientContext &context, AggregateFunction &function,
                                               vector<unique_ptr<Expression>> &arguments) {
     function.return_type = GetGTestAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("g_test_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("g_test_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/gamma_aggregate.cpp
+++ b/src/aggregate_functions/gamma_aggregate.cpp
@@ -333,7 +333,7 @@ static unique_ptr<FunctionData> GammaAggBind(ClientContext &context, AggregateFu
 
     function.return_type = GetGammaAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("gamma_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("gamma_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/huber_aggregate.cpp
+++ b/src/aggregate_functions/huber_aggregate.cpp
@@ -367,7 +367,7 @@ static unique_ptr<FunctionData> HuberAggBind(ClientContext &context, AggregateFu
 
     function.return_type = GetHuberAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("huber_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("huber_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/huber_predict_aggregate.cpp
+++ b/src/aggregate_functions/huber_predict_aggregate.cpp
@@ -448,7 +448,7 @@ static unique_ptr<FunctionData> HuberPredictAggBind(ClientContext &context, Aggr
     }
 
     function.return_type = GetHuberPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("huber_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("huber_fit_predict_agg");
     return std::move(result);
 }
 
@@ -462,7 +462,7 @@ static unique_ptr<FunctionData> HuberPredictAggBindWithSplit(ClientContext &cont
     }
 
     function.return_type = GetHuberPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("huber_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("huber_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/icc_aggregate.cpp
+++ b/src/aggregate_functions/icc_aggregate.cpp
@@ -279,7 +279,7 @@ static unique_ptr<FunctionData> IccAggBind(ClientContext &context, AggregateFunc
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("icc_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("icc_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/isotonic_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/isotonic_fit_predict_aggregate.cpp
@@ -367,7 +367,7 @@ static unique_ptr<FunctionData> IsotonicPredictAggBind(ClientContext &context, A
     }
 
     function.return_type = GetIsotonicPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("isotonic_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("isotonic_fit_predict_agg");
     return std::move(result);
 }
 
@@ -386,7 +386,7 @@ static unique_ptr<FunctionData> IsotonicPredictAggBindWithSplit(ClientContext &c
     }
 
     function.return_type = GetIsotonicPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("isotonic_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("isotonic_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/jarque_bera_aggregate.cpp
+++ b/src/aggregate_functions/jarque_bera_aggregate.cpp
@@ -163,7 +163,7 @@ static void JarqueBeraAggFinalize(Vector &state_vector, AggregateInputData &aggr
 static unique_ptr<FunctionData> JarqueBeraAggBind(ClientContext &context, AggregateFunction &function,
                                                   vector<unique_ptr<Expression>> &arguments) {
     function.return_type = GetJarqueBeraAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("jarque_bera_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("jarque_bera_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/kendall_aggregate.cpp
+++ b/src/aggregate_functions/kendall_aggregate.cpp
@@ -233,7 +233,7 @@ static unique_ptr<FunctionData> KendallAggBind(ClientContext &context, Aggregate
         bind_data->options = KendallMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("kendall_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("kendall_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/kruskal_wallis_aggregate.cpp
+++ b/src/aggregate_functions/kruskal_wallis_aggregate.cpp
@@ -179,7 +179,7 @@ static void KruskalWallisAggFinalize(Vector &state_vector, AggregateInputData &a
 static unique_ptr<FunctionData> KruskalWallisAggBind(ClientContext &context, AggregateFunction &function,
                                                       vector<unique_ptr<Expression>> &arguments) {
     function.return_type = GetKruskalWallisAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("kruskal_wallis_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("kruskal_wallis_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/lars_aggregate.cpp
+++ b/src/aggregate_functions/lars_aggregate.cpp
@@ -309,7 +309,7 @@ static unique_ptr<FunctionData> LarsAggBind(ClientContext &context, AggregateFun
 
     function.return_type = GetLarsAggResultType();
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("lars_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("lars_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/logistic_aggregate.cpp
+++ b/src/aggregate_functions/logistic_aggregate.cpp
@@ -354,7 +354,7 @@ static unique_ptr<FunctionData> LogisticAggBind(ClientContext &context, Aggregat
 
     function.return_type = GetLogisticAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("logistic_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("logistic_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/mann_whitney_aggregate.cpp
+++ b/src/aggregate_functions/mann_whitney_aggregate.cpp
@@ -229,7 +229,7 @@ static unique_ptr<FunctionData> MannWhitneyAggBind(ClientContext &context, Aggre
         bind_data->options = MannWhitneyMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("mann_whitney_u_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("mann_whitney_u_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/mcnemar_aggregate.cpp
+++ b/src/aggregate_functions/mcnemar_aggregate.cpp
@@ -222,7 +222,7 @@ static unique_ptr<FunctionData> McNemarAggBind(ClientContext &context, Aggregate
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("mcnemar_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("mcnemar_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/mmd_aggregate.cpp
+++ b/src/aggregate_functions/mmd_aggregate.cpp
@@ -222,7 +222,7 @@ static unique_ptr<FunctionData> MmdAggBind(ClientContext &context, AggregateFunc
         bind_data->options = MmdMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("mmd_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("mmd_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/negbinom_aggregate.cpp
+++ b/src/aggregate_functions/negbinom_aggregate.cpp
@@ -336,7 +336,7 @@ static unique_ptr<FunctionData> NegBinomAggBind(ClientContext &context, Aggregat
 
     function.return_type = GetNegBinomAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("negbinom_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("negbinom_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/ols_aggregate.cpp
+++ b/src/aggregate_functions/ols_aggregate.cpp
@@ -367,7 +367,7 @@ static unique_ptr<FunctionData> OlsAggBind(ClientContext &context, AggregateFunc
     // Set return type based on options
     function.return_type = GetOlsAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ols_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("ols_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/ols_predict_aggregate.cpp
+++ b/src/aggregate_functions/ols_predict_aggregate.cpp
@@ -453,7 +453,7 @@ static unique_ptr<FunctionData> OlsPredictAggBind(ClientContext &context, Aggreg
     }
 
     function.return_type = GetOlsPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ols_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("ols_fit_predict_agg");
     return std::move(result);
 }
 
@@ -484,7 +484,7 @@ static unique_ptr<FunctionData> OlsPredictAggBindWithSplit(ClientContext &contex
     }
 
     function.return_type = GetOlsPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ols_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("ols_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/pearson_aggregate.cpp
+++ b/src/aggregate_functions/pearson_aggregate.cpp
@@ -221,7 +221,7 @@ static unique_ptr<FunctionData> PearsonAggBind(ClientContext &context, Aggregate
         bind_data->options = CorrelationMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("pearson_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("pearson_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/permutation_t_test_aggregate.cpp
+++ b/src/aggregate_functions/permutation_t_test_aggregate.cpp
@@ -241,7 +241,7 @@ static unique_ptr<FunctionData> PermutationTTestAggBind(ClientContext &context, 
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("permutation_t_test_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("permutation_t_test_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/phi_coefficient_aggregate.cpp
+++ b/src/aggregate_functions/phi_coefficient_aggregate.cpp
@@ -177,7 +177,7 @@ static void PhiCoefficientAggFinalize(Vector &state_vector, AggregateInputData &
 static unique_ptr<FunctionData> PhiCoefficientAggBind(ClientContext &context, AggregateFunction &function,
                                                        vector<unique_ptr<Expression>> &arguments) {
     function.return_type = LogicalType::DOUBLE;
-    PostHogTelemetry::Instance().CaptureFunctionExecution("phi_coefficient_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("phi_coefficient_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/pls_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/pls_fit_predict_aggregate.cpp
@@ -369,7 +369,7 @@ static unique_ptr<FunctionData> PlsPredictAggBind(ClientContext &context, Aggreg
     }
 
     function.return_type = GetPlsPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("pls_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("pls_fit_predict_agg");
     return std::move(result);
 }
 
@@ -391,7 +391,7 @@ static unique_ptr<FunctionData> PlsPredictAggBindWithSplit(ClientContext &contex
     }
 
     function.return_type = GetPlsPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("pls_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("pls_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/poisson_aggregate.cpp
+++ b/src/aggregate_functions/poisson_aggregate.cpp
@@ -377,7 +377,7 @@ static unique_ptr<FunctionData> PoissonAggBind(ClientContext &context, Aggregate
 
     function.return_type = GetPoissonAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("poisson_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("poisson_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/poisson_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/poisson_fit_predict_aggregate.cpp
@@ -546,7 +546,7 @@ static unique_ptr<FunctionData> PoissonFitPredictAggBind(ClientContext &context,
     }
 
     function.return_type = GetPoissonFitPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("poisson_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("poisson_fit_predict_agg");
     return std::move(result);
 }
 
@@ -583,7 +583,7 @@ static unique_ptr<FunctionData> PoissonFitPredictAggBindWithSplit(ClientContext 
     }
 
     function.return_type = GetPoissonFitPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("poisson_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("poisson_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/prop_test_one_aggregate.cpp
+++ b/src/aggregate_functions/prop_test_one_aggregate.cpp
@@ -221,7 +221,7 @@ static unique_ptr<FunctionData> PropTestOneAggBind(ClientContext &context, Aggre
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("prop_test_one_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("prop_test_one_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/prop_test_two_aggregate.cpp
+++ b/src/aggregate_functions/prop_test_two_aggregate.cpp
@@ -240,7 +240,7 @@ static unique_ptr<FunctionData> PropTestTwoAggBind(ClientContext &context, Aggre
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("prop_test_two_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("prop_test_two_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/quantile_fit_predict_aggregate.cpp
+++ b/src/aggregate_functions/quantile_fit_predict_aggregate.cpp
@@ -371,7 +371,7 @@ static unique_ptr<FunctionData> QuantilePredictAggBind(ClientContext &context, A
     }
 
     function.return_type = GetQuantilePredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("quantile_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("quantile_fit_predict_agg");
     return std::move(result);
 }
 
@@ -393,7 +393,7 @@ static unique_ptr<FunctionData> QuantilePredictAggBindWithSplit(ClientContext &c
     }
 
     function.return_type = GetQuantilePredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("quantile_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("quantile_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/ransac_aggregate.cpp
+++ b/src/aggregate_functions/ransac_aggregate.cpp
@@ -413,7 +413,7 @@ static unique_ptr<FunctionData> RansacAggBind(ClientContext &context, AggregateF
 
     function.return_type = GetRansacAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ransac_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("ransac_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/ransac_predict_aggregate.cpp
+++ b/src/aggregate_functions/ransac_predict_aggregate.cpp
@@ -466,7 +466,7 @@ static unique_ptr<FunctionData> RansacPredictAggBind(ClientContext &context, Agg
     }
 
     function.return_type = GetRansacPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ransac_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("ransac_fit_predict_agg");
     return std::move(result);
 }
 
@@ -480,7 +480,7 @@ static unique_ptr<FunctionData> RansacPredictAggBindWithSplit(ClientContext &con
     }
 
     function.return_type = GetRansacPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ransac_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("ransac_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/residuals_diagnostics_aggregate.cpp
+++ b/src/aggregate_functions/residuals_diagnostics_aggregate.cpp
@@ -309,7 +309,7 @@ static void ResidualsDiagnosticsAggFinalize(Vector &state_vector, AggregateInput
 static unique_ptr<FunctionData> ResidualsDiagnosticsAggBind(ClientContext &context, AggregateFunction &function,
                                                             vector<unique_ptr<Expression>> &arguments) {
     function.return_type = GetResidualsDiagnosticsAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("residuals_diagnostics_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("residuals_diagnostics_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/ridge_aggregate.cpp
+++ b/src/aggregate_functions/ridge_aggregate.cpp
@@ -378,7 +378,7 @@ static unique_ptr<FunctionData> RidgeAggBind(ClientContext &context, AggregateFu
     // Set return type based on options
     function.return_type = GetRidgeAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ridge_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("ridge_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/ridge_predict_aggregate.cpp
+++ b/src/aggregate_functions/ridge_predict_aggregate.cpp
@@ -421,7 +421,7 @@ static unique_ptr<FunctionData> RidgePredictAggBind(ClientContext &context, Aggr
     }
 
     function.return_type = GetRidgePredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ridge_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("ridge_fit_predict_agg");
     return std::move(result);
 }
 
@@ -455,7 +455,7 @@ static unique_ptr<FunctionData> RidgePredictAggBindWithSplit(ClientContext &cont
     }
 
     function.return_type = GetRidgePredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ridge_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("ridge_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/rls_aggregate.cpp
+++ b/src/aggregate_functions/rls_aggregate.cpp
@@ -320,7 +320,7 @@ static unique_ptr<FunctionData> RlsAggBind(ClientContext &context, AggregateFunc
     // Set return type
     function.return_type = GetRlsAggResultType();
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("rls_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("rls_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/rls_predict_aggregate.cpp
+++ b/src/aggregate_functions/rls_predict_aggregate.cpp
@@ -402,7 +402,7 @@ static unique_ptr<FunctionData> RlsPredictAggBind(ClientContext &context, Aggreg
     }
 
     function.return_type = GetRlsPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("rls_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("rls_fit_predict_agg");
     return std::move(result);
 }
 
@@ -431,7 +431,7 @@ static unique_ptr<FunctionData> RlsPredictAggBindWithSplit(ClientContext &contex
     }
 
     function.return_type = GetRlsPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("rls_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("rls_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/shapiro_wilk_aggregate.cpp
+++ b/src/aggregate_functions/shapiro_wilk_aggregate.cpp
@@ -166,7 +166,7 @@ static void ShapiroWilkAggFinalize(Vector &state_vector, AggregateInputData &agg
 static unique_ptr<FunctionData> ShapiroWilkAggBind(ClientContext &context, AggregateFunction &function,
                                                     vector<unique_ptr<Expression>> &arguments) {
     function.return_type = GetShapiroWilkAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("shapiro_wilk_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("shapiro_wilk_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/spearman_aggregate.cpp
+++ b/src/aggregate_functions/spearman_aggregate.cpp
@@ -216,7 +216,7 @@ static unique_ptr<FunctionData> SpearmanAggBind(ClientContext &context, Aggregat
         bind_data->options = CorrelationMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("spearman_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("spearman_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/t_test_aggregate.cpp
+++ b/src/aggregate_functions/t_test_aggregate.cpp
@@ -241,7 +241,7 @@ static unique_ptr<FunctionData> TTestAggBind(ClientContext &context, AggregateFu
         bind_data->options = TTestMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("t_test_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("t_test_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/theil_sen_aggregate.cpp
+++ b/src/aggregate_functions/theil_sen_aggregate.cpp
@@ -373,7 +373,7 @@ static unique_ptr<FunctionData> TheilSenAggBind(ClientContext &context, Aggregat
 
     function.return_type = GetTheilSenAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("theilsen_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("theilsen_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/theil_sen_predict_aggregate.cpp
+++ b/src/aggregate_functions/theil_sen_predict_aggregate.cpp
@@ -433,7 +433,7 @@ static unique_ptr<FunctionData> TheilSenPredictAggBind(ClientContext &context, A
     }
 
     function.return_type = GetTheilSenPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("theilsen_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("theilsen_fit_predict_agg");
     return std::move(result);
 }
 
@@ -448,7 +448,7 @@ static unique_ptr<FunctionData> TheilSenPredictAggBindWithSplit(ClientContext &c
     }
 
     function.return_type = GetTheilSenPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("theilsen_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("theilsen_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/tost_correlation_aggregate.cpp
+++ b/src/aggregate_functions/tost_correlation_aggregate.cpp
@@ -263,7 +263,7 @@ static unique_ptr<FunctionData> TostCorrelationAggBind(ClientContext &context, A
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("tost_correlation_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("tost_correlation_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/tost_paired_aggregate.cpp
+++ b/src/aggregate_functions/tost_paired_aggregate.cpp
@@ -252,7 +252,7 @@ static unique_ptr<FunctionData> TostPairedAggBind(ClientContext &context, Aggreg
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("tost_paired_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("tost_paired_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/tost_t_test_aggregate.cpp
+++ b/src/aggregate_functions/tost_t_test_aggregate.cpp
@@ -250,7 +250,7 @@ static unique_ptr<FunctionData> TostTTestAggBind(ClientContext &context, Aggrega
         bind_data->options = TostMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("tost_t_test_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("tost_t_test_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/tweedie_aggregate.cpp
+++ b/src/aggregate_functions/tweedie_aggregate.cpp
@@ -344,7 +344,7 @@ static unique_ptr<FunctionData> TweedieAggBind(ClientContext &context, Aggregate
 
     function.return_type = GetTweedieAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("tweedie_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("tweedie_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/vif_aggregate.cpp
+++ b/src/aggregate_functions/vif_aggregate.cpp
@@ -191,7 +191,7 @@ static void VifAggFinalize(Vector &state_vector, AggregateInputData &aggr_input_
 static unique_ptr<FunctionData> VifAggBind(ClientContext &context, AggregateFunction &function,
                                            vector<unique_ptr<Expression>> &arguments) {
     function.return_type = LogicalType::LIST(LogicalType::DOUBLE);
-    PostHogTelemetry::Instance().CaptureFunctionExecution("vif_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("vif_agg");
     return nullptr;
 }
 

--- a/src/aggregate_functions/wilcoxon_signed_rank_aggregate.cpp
+++ b/src/aggregate_functions/wilcoxon_signed_rank_aggregate.cpp
@@ -234,7 +234,7 @@ static unique_ptr<FunctionData> WilcoxonSignedRankAggBind(ClientContext &context
         bind_data->options = WilcoxonMapOptions::ParseFromValue(options_val);
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("wilcoxon_signed_rank_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("wilcoxon_signed_rank_agg");
     return bind_data;
 }
 

--- a/src/aggregate_functions/wls_aggregate.cpp
+++ b/src/aggregate_functions/wls_aggregate.cpp
@@ -391,7 +391,7 @@ static unique_ptr<FunctionData> WlsAggBind(ClientContext &context, AggregateFunc
     // Set return type based on options
     function.return_type = GetWlsAggResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("wls_fit_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("wls_fit_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/wls_predict_aggregate.cpp
+++ b/src/aggregate_functions/wls_predict_aggregate.cpp
@@ -426,7 +426,7 @@ static unique_ptr<FunctionData> WlsPredictAggBind(ClientContext &context, Aggreg
     }
 
     function.return_type = GetWlsPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("wls_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("wls_fit_predict_agg");
     return std::move(result);
 }
 
@@ -456,7 +456,7 @@ static unique_ptr<FunctionData> WlsPredictAggBindWithSplit(ClientContext &contex
     }
 
     function.return_type = GetWlsPredictAggResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("wls_fit_predict_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("wls_fit_predict_agg");
     return std::move(result);
 }
 

--- a/src/aggregate_functions/yuen_aggregate.cpp
+++ b/src/aggregate_functions/yuen_aggregate.cpp
@@ -257,7 +257,7 @@ static unique_ptr<FunctionData> YuenAggBind(ClientContext &context, AggregateFun
         }
     }
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("yuen_agg");
+    PostHogTelemetry::Instance().RecordFunctionCall("yuen_agg");
     return bind_data;
 }
 

--- a/src/anofox_statistics_extension.cpp
+++ b/src/anofox_statistics_extension.cpp
@@ -61,6 +61,8 @@ void LoadInternal(ExtensionLoader &loader) {
 #else
     version = "0.1.0";
 #endif
+    telemetry.SetProduct("anofox_statistics", version, "oss");
+    telemetry.AssociateGroup("deployment", PostHogTelemetry::GetDistinctId());
     telemetry.CaptureExtensionLoad("anofox_statistics", version);
 #endif // ANOFOX_TELEMETRY_ENABLED
 

--- a/src/scalar_functions/aic_bic.cpp
+++ b/src/scalar_functions/aic_bic.cpp
@@ -11,7 +11,7 @@ namespace duckdb {
 
 // AIC function: anofox_stats_aic(rss, n, k) -> DOUBLE
 static void AicFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("aic");
+    PostHogTelemetry::Instance().RecordFunctionCall("aic");
     auto &rss_vec = args.data[0];
     auto &n_vec = args.data[1];
     auto &k_vec = args.data[2];
@@ -61,7 +61,7 @@ static void AicFunction(DataChunk &args, ExpressionState &state, Vector &result)
 
 // BIC function: anofox_stats_bic(rss, n, k) -> DOUBLE
 static void BicFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("bic");
+    PostHogTelemetry::Instance().RecordFunctionCall("bic");
     auto &rss_vec = args.data[0];
     auto &n_vec = args.data[1];
     auto &k_vec = args.data[2];

--- a/src/scalar_functions/jarque_bera.cpp
+++ b/src/scalar_functions/jarque_bera.cpp
@@ -29,7 +29,7 @@ static LogicalType GetJarqueBeraResultType() {
 static unique_ptr<FunctionData> JarqueBeraBind(ClientContext &context, ScalarFunction &bound_function,
                                                vector<unique_ptr<Expression>> &arguments) {
     bound_function.return_type = GetJarqueBeraResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("jarque_bera");
+    PostHogTelemetry::Instance().RecordFunctionCall("jarque_bera");
     return nullptr;
 }
 

--- a/src/scalar_functions/residuals_diagnostics.cpp
+++ b/src/scalar_functions/residuals_diagnostics.cpp
@@ -28,7 +28,7 @@ static LogicalType GetResidualsDiagnosticsResultType() {
 static unique_ptr<FunctionData> ResidualsDiagnosticsBind(ClientContext &context, ScalarFunction &bound_function,
                                                          vector<unique_ptr<Expression>> &arguments) {
     bound_function.return_type = GetResidualsDiagnosticsResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("residuals_diagnostics");
+    PostHogTelemetry::Instance().RecordFunctionCall("residuals_diagnostics");
     return nullptr;
 }
 

--- a/src/scalar_functions/vif.cpp
+++ b/src/scalar_functions/vif.cpp
@@ -31,7 +31,7 @@ static vector<double> ExtractDoubleList(Vector &vec, idx_t row_idx) {
 // VIF function: anofox_stats_vif(x) -> LIST(DOUBLE)
 // x: LIST(LIST(DOUBLE)) - feature data (list of feature columns)
 static void VifFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("vif");
+    PostHogTelemetry::Instance().RecordFunctionCall("vif");
     auto &x_vec = args.data[0]; // LIST(LIST(DOUBLE))
 
     idx_t count = args.size();

--- a/src/table_functions/elasticnet_fit.cpp
+++ b/src/table_functions/elasticnet_fit.cpp
@@ -91,7 +91,7 @@ static unique_ptr<FunctionData> ElasticNetFitBind(ClientContext &context, Scalar
     // Set return type
     bound_function.return_type = GetElasticNetResultType();
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("elasticnet_fit");
+    PostHogTelemetry::Instance().RecordFunctionCall("elasticnet_fit");
     return std::move(result);
 }
 

--- a/src/table_functions/huber_fit.cpp
+++ b/src/table_functions/huber_fit.cpp
@@ -101,7 +101,7 @@ static unique_ptr<FunctionData> HuberFitBind(ClientContext &context, ScalarFunct
 
     bound_function.return_type = GetHuberResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("huber_fit");
+    PostHogTelemetry::Instance().RecordFunctionCall("huber_fit");
     return std::move(result);
 }
 

--- a/src/table_functions/ols_fit.cpp
+++ b/src/table_functions/ols_fit.cpp
@@ -94,7 +94,7 @@ static unique_ptr<FunctionData> OlsFitBind(ClientContext &context, ScalarFunctio
     // Set return type
     bound_function.return_type = GetOlsResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ols_fit");
+    PostHogTelemetry::Instance().RecordFunctionCall("ols_fit");
     return std::move(result);
 }
 

--- a/src/table_functions/predict.cpp
+++ b/src/table_functions/predict.cpp
@@ -32,7 +32,7 @@ static vector<double> ExtractDoubleList(Vector &vec, idx_t row_idx) {
 
 // Predict function: anofox_stats_predict(x, coefficients, intercept) -> LIST(DOUBLE)
 static void PredictFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-    PostHogTelemetry::Instance().CaptureFunctionExecution("predict");
+    PostHogTelemetry::Instance().RecordFunctionCall("predict");
     auto &x_vec = args.data[0];         // LIST(LIST(DOUBLE)) - new feature data
     auto &coef_vec = args.data[1];      // LIST(DOUBLE) - coefficients
     auto &intercept_vec = args.data[2]; // DOUBLE - intercept (can be NULL)

--- a/src/table_functions/ransac_fit.cpp
+++ b/src/table_functions/ransac_fit.cpp
@@ -126,7 +126,7 @@ static unique_ptr<FunctionData> RansacFitBind(ClientContext &context, ScalarFunc
 
     bound_function.return_type = GetRansacResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ransac_fit");
+    PostHogTelemetry::Instance().RecordFunctionCall("ransac_fit");
     return std::move(result);
 }
 

--- a/src/table_functions/ridge_fit.cpp
+++ b/src/table_functions/ridge_fit.cpp
@@ -102,7 +102,7 @@ static unique_ptr<FunctionData> RidgeFitBind(ClientContext &context, ScalarFunct
     // Set return type
     bound_function.return_type = GetRidgeResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ridge_fit");
+    PostHogTelemetry::Instance().RecordFunctionCall("ridge_fit");
     return std::move(result);
 }
 

--- a/src/table_functions/rls_fit.cpp
+++ b/src/table_functions/rls_fit.cpp
@@ -73,7 +73,7 @@ static unique_ptr<FunctionData> RlsFitBind(ClientContext &context, ScalarFunctio
     // Set return type
     bound_function.return_type = GetRlsResultType();
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("rls_fit");
+    PostHogTelemetry::Instance().RecordFunctionCall("rls_fit");
     return std::move(result);
 }
 

--- a/src/table_functions/theil_sen_fit.cpp
+++ b/src/table_functions/theil_sen_fit.cpp
@@ -109,7 +109,7 @@ static unique_ptr<FunctionData> TheilSenFitBind(ClientContext &context, ScalarFu
 
     bound_function.return_type = GetTheilSenResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("theilsen_fit");
+    PostHogTelemetry::Instance().RecordFunctionCall("theilsen_fit");
     return std::move(result);
 }
 

--- a/src/table_functions/wls_fit.cpp
+++ b/src/table_functions/wls_fit.cpp
@@ -94,7 +94,7 @@ static unique_ptr<FunctionData> WlsFitBind(ClientContext &context, ScalarFunctio
     // Set return type
     bound_function.return_type = GetWlsResultType(result->compute_inference);
 
-    PostHogTelemetry::Instance().CaptureFunctionExecution("wls_fit");
+    PostHogTelemetry::Instance().RecordFunctionCall("wls_fit");
     return std::move(result);
 }
 

--- a/src/window_functions/elasticnet_fit_predict.cpp
+++ b/src/window_functions/elasticnet_fit_predict.cpp
@@ -320,7 +320,7 @@ static unique_ptr<FunctionData> ElasticNetFitPredictBind(ClientContext &context,
     }
 
     function.return_type = GetElasticNetFitPredictResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("elasticnet_fit_predict");
+    PostHogTelemetry::Instance().RecordFunctionCall("elasticnet_fit_predict");
     return std::move(result);
 }
 

--- a/src/window_functions/huber_fit_predict.cpp
+++ b/src/window_functions/huber_fit_predict.cpp
@@ -352,7 +352,7 @@ static unique_ptr<FunctionData> HuberFitPredictBind(ClientContext &context, Aggr
     }
 
     function.return_type = GetHuberFitPredictResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("huber_fit_predict");
+    PostHogTelemetry::Instance().RecordFunctionCall("huber_fit_predict");
     return std::move(result);
 }
 

--- a/src/window_functions/ols_fit_predict.cpp
+++ b/src/window_functions/ols_fit_predict.cpp
@@ -350,7 +350,7 @@ static unique_ptr<FunctionData> OlsFitPredictBind(ClientContext &context, Aggreg
     }
 
     function.return_type = GetOlsFitPredictResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ols_fit_predict");
+    PostHogTelemetry::Instance().RecordFunctionCall("ols_fit_predict");
     return std::move(result);
 }
 

--- a/src/window_functions/ransac_fit_predict.cpp
+++ b/src/window_functions/ransac_fit_predict.cpp
@@ -380,7 +380,7 @@ static unique_ptr<FunctionData> RansacFitPredictBind(ClientContext &context, Agg
     }
 
     function.return_type = GetRansacFitPredictResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ransac_fit_predict");
+    PostHogTelemetry::Instance().RecordFunctionCall("ransac_fit_predict");
     return std::move(result);
 }
 

--- a/src/window_functions/ridge_fit_predict.cpp
+++ b/src/window_functions/ridge_fit_predict.cpp
@@ -304,7 +304,7 @@ static unique_ptr<FunctionData> RidgeFitPredictBind(ClientContext &context, Aggr
     }
 
     function.return_type = GetRidgeFitPredictResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("ridge_fit_predict");
+    PostHogTelemetry::Instance().RecordFunctionCall("ridge_fit_predict");
     return std::move(result);
 }
 

--- a/src/window_functions/rls_fit_predict.cpp
+++ b/src/window_functions/rls_fit_predict.cpp
@@ -289,7 +289,7 @@ static unique_ptr<FunctionData> RlsFitPredictBind(ClientContext &context, Aggreg
     }
 
     function.return_type = GetRlsFitPredictResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("rls_fit_predict");
+    PostHogTelemetry::Instance().RecordFunctionCall("rls_fit_predict");
     return std::move(result);
 }
 

--- a/src/window_functions/theil_sen_fit_predict.cpp
+++ b/src/window_functions/theil_sen_fit_predict.cpp
@@ -355,7 +355,7 @@ static unique_ptr<FunctionData> TheilSenFitPredictBind(ClientContext &context, A
     }
 
     function.return_type = GetTheilSenFitPredictResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("theilsen_fit_predict");
+    PostHogTelemetry::Instance().RecordFunctionCall("theilsen_fit_predict");
     return std::move(result);
 }
 

--- a/src/window_functions/wls_fit_predict.cpp
+++ b/src/window_functions/wls_fit_predict.cpp
@@ -306,7 +306,7 @@ static unique_ptr<FunctionData> WlsFitPredictBind(ClientContext &context, Aggreg
     }
 
     function.return_type = GetWlsFitPredictResultType();
-    PostHogTelemetry::Instance().CaptureFunctionExecution("wls_fit_predict");
+    PostHogTelemetry::Instance().RecordFunctionCall("wls_fit_predict");
     return std::move(result);
 }
 


### PR DESCRIPTION
Adopts the cross-product **posthog-telemetry schema-2** telemetry.

- Bump `posthog-telemetry` submodule to the analysis-first API (`e41682b`); keeps the teardown-safety fix.
- Identify the product at load: `SetProduct("anofox_statistics", …, "oss")` + `AssociateGroup("deployment", …)`.
- All `CaptureFunctionExecution(...)` → `RecordFunctionCall(...)` (aggregated `function_executed` per function per session).
- Add `TELEMETRY.md`; gitignore `.cache/`.

Privacy: only enumerated/numeric property values ever leave the machine. Opt-out unchanged (`SET anofox_statistics_telemetry_enabled=false` / `DATAZOO_DISABLE_TELEMETRY=1`).

Note: the local dev box (GCC 16 + ASan) hit a DuckDB static-constexpr ODR link quirk on an incremental build; CI's toolchain builds this extension cleanly (as for prior releases).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786522891&installation_id=142929061&pr_number=104&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F104&signature=37414e9dc6f358b202c23c680d99ca43e1955fe147990999972bc67fe851a28f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->