### PR TITLE
feat(glm): offset support, NULL list elements, and converged field (#110, #111)

### DIFF
--- a/crates/anofox-stats-core/src/models/glm.rs
+++ b/crates/anofox-stats-core/src/models/glm.rs
@@ -87,7 +87,7 @@ pub fn fit_poisson(y: &[f64], x: &[Vec<f64>], options: &PoissonOptions) -> Stats
         lambda: options.lambda,
         priors: options.prior_opts.priors.clone(),
         vcov: options.prior_opts.vcov,
-        offset_column: None,
+        offset_column: options.offset_column,
         // Poisson has always dropped constant columns and reported NaN for them.
         constant_policy: ConstantColumnPolicy::Drop,
     };
@@ -137,7 +137,7 @@ pub fn fit_binomial(
         lambda: options.lambda,
         priors: options.prior_opts.priors.clone(),
         vcov: options.prior_opts.vcov,
-        offset_column: None,
+        offset_column: options.offset_column,
         constant_policy: ConstantColumnPolicy::Keep,
     };
 
@@ -200,7 +200,7 @@ pub fn fit_negbinomial(
         lambda: options.lambda,
         priors: options.prior_opts.priors.clone(),
         vcov: options.prior_opts.vcov,
-        offset_column: None,
+        offset_column: options.offset_column,
         constant_policy: ConstantColumnPolicy::Keep,
     };
 
@@ -297,7 +297,7 @@ pub fn fit_tweedie(y: &[f64], x: &[Vec<f64>], options: &TweedieOptions) -> Stats
         lambda: options.lambda,
         priors: options.prior_opts.priors.clone(),
         vcov: options.prior_opts.vcov,
-        offset_column: None,
+        offset_column: options.offset_column,
         constant_policy: ConstantColumnPolicy::Keep,
     };
 
@@ -338,7 +338,7 @@ pub fn fit_gamma(y: &[f64], x: &[Vec<f64>], options: &GammaOptions) -> StatsResu
         lambda: options.lambda,
         priors: options.prior_opts.priors.clone(),
         vcov: options.prior_opts.vcov,
-        offset_column: None,
+        offset_column: options.offset_column,
         constant_policy: ConstantColumnPolicy::Keep,
     };
 
@@ -396,7 +396,7 @@ pub fn fit_logistic(
         lambda: options.lambda,
         priors: options.prior_opts.priors.clone(),
         vcov: options.prior_opts.vcov,
-        offset_column: None,
+        offset_column: options.offset_column,
         constant_policy: ConstantColumnPolicy::Keep,
     };
 

--- a/crates/anofox-stats-core/src/types.rs
+++ b/crates/anofox-stats-core/src/types.rs
@@ -643,6 +643,10 @@ pub struct PoissonOptions {
     pub lambda: f64,
     /// Explicit per-coefficient priors and covariance type (see [`GlmPriorOptions`]).
     pub prior_opts: GlmPriorOptions,
+    /// 1-based index into `x` of a column used as an offset (added to the linear
+    /// predictor with coefficient fixed at 1 and dropped from the design).
+    /// `None` = no offset. The value is used as-is; take logs upstream if needed.
+    pub offset_column: Option<usize>,
 }
 
 impl Default for PoissonOptions {
@@ -656,6 +660,7 @@ impl Default for PoissonOptions {
             confidence_level: 0.95,
             lambda: 0.0,
             prior_opts: GlmPriorOptions::default(),
+            offset_column: None,
         }
     }
 }
@@ -679,6 +684,10 @@ pub struct BinomialOptions {
     pub lambda: f64,
     /// Explicit per-coefficient priors and covariance type (see [`GlmPriorOptions`]).
     pub prior_opts: GlmPriorOptions,
+    /// 1-based index into `x` of a column used as an offset (added to the linear
+    /// predictor with coefficient fixed at 1 and dropped from the design).
+    /// `None` = no offset. The value is used as-is; take logs upstream if needed.
+    pub offset_column: Option<usize>,
 }
 
 impl Default for BinomialOptions {
@@ -692,6 +701,7 @@ impl Default for BinomialOptions {
             confidence_level: 0.95,
             lambda: 0.0,
             prior_opts: GlmPriorOptions::default(),
+            offset_column: None,
         }
     }
 }
@@ -715,6 +725,10 @@ pub struct NegBinomialOptions {
     pub lambda: f64,
     /// Explicit per-coefficient priors and covariance type (see [`GlmPriorOptions`]).
     pub prior_opts: GlmPriorOptions,
+    /// 1-based index into `x` of a column used as an offset (added to the linear
+    /// predictor with coefficient fixed at 1 and dropped from the design).
+    /// `None` = no offset. The value is used as-is; take logs upstream if needed.
+    pub offset_column: Option<usize>,
 }
 
 impl Default for NegBinomialOptions {
@@ -728,6 +742,7 @@ impl Default for NegBinomialOptions {
             confidence_level: 0.95,
             lambda: 0.0,
             prior_opts: GlmPriorOptions::default(),
+            offset_column: None,
         }
     }
 }
@@ -752,6 +767,10 @@ pub struct TweedieOptions {
     pub lambda: f64,
     /// Explicit per-coefficient priors and covariance type (see [`GlmPriorOptions`]).
     pub prior_opts: GlmPriorOptions,
+    /// 1-based index into `x` of a column used as an offset (added to the linear
+    /// predictor with coefficient fixed at 1 and dropped from the design).
+    /// `None` = no offset. The value is used as-is; take logs upstream if needed.
+    pub offset_column: Option<usize>,
 }
 
 impl Default for TweedieOptions {
@@ -765,6 +784,7 @@ impl Default for TweedieOptions {
             confidence_level: 0.95,
             lambda: 0.0,
             prior_opts: GlmPriorOptions::default(),
+            offset_column: None,
         }
     }
 }
@@ -786,6 +806,10 @@ pub struct GammaOptions {
     pub lambda: f64,
     /// Explicit per-coefficient priors and covariance type (see [`GlmPriorOptions`]).
     pub prior_opts: GlmPriorOptions,
+    /// 1-based index into `x` of a column used as an offset (added to the linear
+    /// predictor with coefficient fixed at 1 and dropped from the design).
+    /// `None` = no offset. The value is used as-is; take logs upstream if needed.
+    pub offset_column: Option<usize>,
 }
 
 impl Default for GammaOptions {
@@ -798,6 +822,7 @@ impl Default for GammaOptions {
             confidence_level: 0.95,
             lambda: 0.0,
             prior_opts: GlmPriorOptions::default(),
+            offset_column: None,
         }
     }
 }
@@ -822,6 +847,10 @@ pub struct LogisticOptions {
     pub confidence_level: f64,
     /// Explicit per-coefficient priors and covariance type (see [`GlmPriorOptions`]).
     pub prior_opts: GlmPriorOptions,
+    /// 1-based index into `x` of a column used as an offset (added to the linear
+    /// predictor with coefficient fixed at 1 and dropped from the design).
+    /// `None` = no offset. The value is used as-is; take logs upstream if needed.
+    pub offset_column: Option<usize>,
 }
 
 impl Default for LogisticOptions {
@@ -835,6 +864,7 @@ impl Default for LogisticOptions {
             compute_inference: false,
             confidence_level: 0.95,
             prior_opts: GlmPriorOptions::default(),
+            offset_column: None,
         }
     }
 }

--- a/crates/anofox-stats-ffi/src/lib.rs
+++ b/crates/anofox-stats-ffi/src/lib.rs
@@ -2410,6 +2410,11 @@ pub unsafe extern "C" fn anofox_poisson_fit(
             priors: priors_from_ffi(options.priors, options.priors_len),
             vcov: vcov_from_ffi(options.vcov),
         },
+        offset_column: if options.offset_column == 0 {
+            None
+        } else {
+            Some(options.offset_column)
+        },
     };
 
     let fit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -2453,6 +2458,7 @@ pub unsafe extern "C" fn anofox_poisson_fit(
                 n_observations: result.core.n_observations,
                 n_features: result.core.n_features,
                 iterations: result.core.iterations,
+                converged: result.core.converged,
             };
 
             // Fill inference if available
@@ -2558,6 +2564,11 @@ pub unsafe extern "C" fn anofox_binomial_fit(
             priors: priors_from_ffi(options.priors, options.priors_len),
             vcov: vcov_from_ffi(options.vcov),
         },
+        offset_column: if options.offset_column == 0 {
+            None
+        } else {
+            Some(options.offset_column)
+        },
     };
 
     let fit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -2601,6 +2612,7 @@ pub unsafe extern "C" fn anofox_binomial_fit(
                 n_observations: result.core.n_observations,
                 n_features: result.core.n_features,
                 iterations: result.core.iterations,
+                converged: result.core.converged,
             };
 
             if !out_inference.is_null() {
@@ -2704,6 +2716,11 @@ pub unsafe extern "C" fn anofox_negbinomial_fit(
             priors: priors_from_ffi(options.priors, options.priors_len),
             vcov: vcov_from_ffi(options.vcov),
         },
+        offset_column: if options.offset_column == 0 {
+            None
+        } else {
+            Some(options.offset_column)
+        },
     };
 
     let fit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -2750,6 +2767,7 @@ pub unsafe extern "C" fn anofox_negbinomial_fit(
                 n_observations: result.core.n_observations,
                 n_features: result.core.n_features,
                 iterations: result.core.iterations,
+                converged: result.core.converged,
             };
 
             if !out_inference.is_null() {
@@ -2848,6 +2866,11 @@ pub unsafe extern "C" fn anofox_tweedie_fit(
             priors: priors_from_ffi(options.priors, options.priors_len),
             vcov: vcov_from_ffi(options.vcov),
         },
+        offset_column: if options.offset_column == 0 {
+            None
+        } else {
+            Some(options.offset_column)
+        },
     };
 
     let fit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -2891,6 +2914,7 @@ pub unsafe extern "C" fn anofox_tweedie_fit(
                 n_observations: result.core.n_observations,
                 n_features: result.core.n_features,
                 iterations: result.core.iterations,
+                converged: result.core.converged,
             };
 
             if !out_inference.is_null() {
@@ -2988,6 +3012,11 @@ pub unsafe extern "C" fn anofox_gamma_fit(
             priors: priors_from_ffi(options.priors, options.priors_len),
             vcov: vcov_from_ffi(options.vcov),
         },
+        offset_column: if options.offset_column == 0 {
+            None
+        } else {
+            Some(options.offset_column)
+        },
     };
 
     let fit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -3031,6 +3060,7 @@ pub unsafe extern "C" fn anofox_gamma_fit(
                 n_observations: result.core.n_observations,
                 n_features: result.core.n_features,
                 iterations: result.core.iterations,
+                converged: result.core.converged,
             };
 
             if !out_inference.is_null() {
@@ -3131,6 +3161,11 @@ pub unsafe extern "C" fn anofox_logistic_fit(
             priors: priors_from_ffi(options.priors, options.priors_len),
             vcov: vcov_from_ffi(options.vcov),
         },
+        offset_column: if options.offset_column == 0 {
+            None
+        } else {
+            Some(options.offset_column)
+        },
     };
 
     let fit_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -3175,6 +3210,7 @@ pub unsafe extern "C" fn anofox_logistic_fit(
                 n_observations: result.core.n_observations,
                 n_features: result.core.n_features,
                 iterations: result.core.iterations,
+                converged: result.core.converged,
             };
 
             if !out_inference.is_null() {

--- a/crates/anofox-stats-ffi/src/types.rs
+++ b/crates/anofox-stats-ffi/src/types.rs
@@ -283,6 +283,10 @@ pub struct LogisticOptionsFFI {
     pub priors_len: usize,
     /// How to compute the coefficient covariance.
     pub vcov: VcovTypeFFI,
+    /// 1-based index into `x` of an offset column (0 = none). The column is added
+    /// to the linear predictor with coefficient fixed at 1 and dropped from the
+    /// design. Used as-is; take logs upstream if the link requires it.
+    pub offset_column: usize,
 }
 
 impl Default for LogisticOptionsFFI {
@@ -298,6 +302,7 @@ impl Default for LogisticOptionsFFI {
             priors: std::ptr::null(),
             priors_len: 0,
             vcov: VcovTypeFFI::Laplace,
+            offset_column: 0,
         }
     }
 }
@@ -731,6 +736,10 @@ pub struct PoissonOptionsFFI {
     pub priors_len: usize,
     /// How to compute the coefficient covariance.
     pub vcov: VcovTypeFFI,
+    /// 1-based index into `x` of an offset column (0 = none). The column is added
+    /// to the linear predictor with coefficient fixed at 1 and dropped from the
+    /// design. Used as-is; take logs upstream if the link requires it.
+    pub offset_column: usize,
 }
 
 impl Default for PoissonOptionsFFI {
@@ -746,6 +755,7 @@ impl Default for PoissonOptionsFFI {
             priors: std::ptr::null(),
             priors_len: 0,
             vcov: VcovTypeFFI::Laplace,
+            offset_column: 0,
         }
     }
 }
@@ -773,6 +783,10 @@ pub struct BinomialOptionsFFI {
     pub priors_len: usize,
     /// How to compute the coefficient covariance.
     pub vcov: VcovTypeFFI,
+    /// 1-based index into `x` of an offset column (0 = none). The column is added
+    /// to the linear predictor with coefficient fixed at 1 and dropped from the
+    /// design. Used as-is; take logs upstream if the link requires it.
+    pub offset_column: usize,
 }
 
 impl Default for BinomialOptionsFFI {
@@ -788,6 +802,7 @@ impl Default for BinomialOptionsFFI {
             priors: std::ptr::null(),
             priors_len: 0,
             vcov: VcovTypeFFI::Laplace,
+            offset_column: 0,
         }
     }
 }
@@ -815,6 +830,10 @@ pub struct NegBinomialOptionsFFI {
     pub priors_len: usize,
     /// How to compute the coefficient covariance.
     pub vcov: VcovTypeFFI,
+    /// 1-based index into `x` of an offset column (0 = none). The column is added
+    /// to the linear predictor with coefficient fixed at 1 and dropped from the
+    /// design. Used as-is; take logs upstream if the link requires it.
+    pub offset_column: usize,
 }
 
 impl Default for NegBinomialOptionsFFI {
@@ -830,6 +849,7 @@ impl Default for NegBinomialOptionsFFI {
             priors: std::ptr::null(),
             priors_len: 0,
             vcov: VcovTypeFFI::Laplace,
+            offset_column: 0,
         }
     }
 }
@@ -857,6 +877,10 @@ pub struct TweedieOptionsFFI {
     pub priors_len: usize,
     /// How to compute the coefficient covariance.
     pub vcov: VcovTypeFFI,
+    /// 1-based index into `x` of an offset column (0 = none). The column is added
+    /// to the linear predictor with coefficient fixed at 1 and dropped from the
+    /// design. Used as-is; take logs upstream if the link requires it.
+    pub offset_column: usize,
 }
 
 impl Default for TweedieOptionsFFI {
@@ -872,6 +896,7 @@ impl Default for TweedieOptionsFFI {
             priors: std::ptr::null(),
             priors_len: 0,
             vcov: VcovTypeFFI::Laplace,
+            offset_column: 0,
         }
     }
 }
@@ -891,6 +916,10 @@ pub struct GammaOptionsFFI {
     pub priors_len: usize,
     /// How to compute the coefficient covariance.
     pub vcov: VcovTypeFFI,
+    /// 1-based index into `x` of an offset column (0 = none). The column is added
+    /// to the linear predictor with coefficient fixed at 1 and dropped from the
+    /// design. Used as-is; take logs upstream if the link requires it.
+    pub offset_column: usize,
 }
 
 impl Default for GammaOptionsFFI {
@@ -905,6 +934,7 @@ impl Default for GammaOptionsFFI {
             priors: std::ptr::null(),
             priors_len: 0,
             vcov: VcovTypeFFI::Laplace,
+            offset_column: 0,
         }
     }
 }
@@ -934,6 +964,9 @@ pub struct GlmFitResultCore {
     pub n_features: usize,
     /// Number of iterations to converge
     pub iterations: u32,
+    /// Whether the IRLS solver reached the convergence tolerance. Appended last to
+    /// preserve the ABI; every construction site must set it explicitly.
+    pub converged: bool,
 }
 
 impl Default for GlmFitResultCore {
@@ -950,6 +983,7 @@ impl Default for GlmFitResultCore {
             n_observations: 0,
             n_features: 0,
             iterations: 0,
+            converged: false,
         }
     }
 }

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -601,6 +601,7 @@ anofox_stats_poisson_fit_agg(
 | tolerance | DOUBLE | 1e-8 | Convergence tolerance |
 | compute_inference | BOOLEAN | false | Compute z-tests, p-values, CIs |
 | confidence_level | DOUBLE | 0.95 | CI confidence level |
+| offset | INTEGER | (none) | 1-based index into `x` of an offset column, added to the linear predictor with coefficient fixed at 1 and removed from the design. Used as-is (take logs upstream if the link requires it). Applies to all six GLM aggregates. |
 
 **Returns:** [GlmFitResult](#glmfitresult-structure) STRUCT
 
@@ -2979,6 +2980,38 @@ STRUCT(
     conf_int_upper LIST(DOUBLE)
 )
 ```
+
+### GlmFitResult Structure
+
+Return type for the GLM aggregates (`poisson_fit_agg`, `binomial_fit_agg`,
+`negbinom_fit_agg`, `tweedie_fit_agg`, `gamma_fit_agg`, `logistic_fit_agg`).
+
+```
+STRUCT(
+    coefficients LIST(DOUBLE),
+    intercept DOUBLE,
+    deviance DOUBLE,
+    null_deviance DOUBLE,
+    pseudo_r_squared DOUBLE,
+    aic DOUBLE,
+    dispersion DOUBLE,
+    n_observations BIGINT,
+    n_features BIGINT,
+    iterations INTEGER,
+    converged BOOLEAN,       -- whether IRLS reached the convergence tolerance
+    -- When compute_inference=true:
+    std_errors LIST(DOUBLE),
+    z_values LIST(DOUBLE),
+    p_values LIST(DOUBLE),
+    ci_lower LIST(DOUBLE),
+    ci_upper LIST(DOUBLE)
+)
+```
+
+> Note: `converged` was added as a first-class field so non-convergence is
+> reported rather than surfacing only as a NULL result. When an `offset` is
+> supplied, the offset column is dropped from the design, so `coefficients` and
+> `n_features` count one fewer than the input feature list.
 
 ### Accessing Results
 

--- a/docs/api/glm/poisson.md
+++ b/docs/api/glm/poisson.md
@@ -33,8 +33,11 @@ anofox_stats_poisson_fit_agg(
 | compute_inference | BOOLEAN | false | Compute z-tests, p-values, CIs |
 | confidence_level | DOUBLE | 0.95 | CI confidence level |
 | glm_lambda | DOUBLE | 0.0 | L2 regularization strength (0 = no regularization) |
+| offset | INTEGER | (none) | 1-based index into `x` of a column to use as an offset. The column is added to the linear predictor with coefficient fixed at 1 and removed from the design. Values are used as-is — take logs upstream if the link requires it (e.g. `log(exposure)` for the log link). |
 
 **Returns:** [GlmFitResult](../reference/return_types.md#glmfitresult-structure) STRUCT
+
+The returned STRUCT includes a `converged BOOLEAN` field reporting whether IRLS reached the convergence tolerance. `offset` and `converged` are available on all six GLM aggregates (`poisson`, `binomial`, `negbinom`, `tweedie`, `gamma`, `logistic`).
 
 **Example:**
 ```sql

--- a/src/aggregate_functions/binomial_aggregate.cpp
+++ b/src/aggregate_functions/binomial_aggregate.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <vector>
 
 #include "duckdb.hpp"
@@ -32,10 +33,11 @@ struct BinomialAggregateState {
 	double tolerance;
 	bool compute_inference;
 	double confidence_level;
+	idx_t offset_column;
 
 	BinomialAggregateState()
 	    : n_features(0), initialized(false), fit_intercept(true), link(ANOFOX_BINOMIAL_LINK_LOGIT), max_iterations(100),
-	      tolerance(1e-8), compute_inference(false), confidence_level(0.95) {
+	      tolerance(1e-8), compute_inference(false), confidence_level(0.95), offset_column(0) {
 	}
 
 	void Reset() {
@@ -50,6 +52,7 @@ struct BinomialAggregateState {
 struct BinomialAggregateBindData : public FunctionData {
 	GlmPriorBindData prior_opts;
 	double glm_lambda = 0.0;
+	idx_t offset_column = 0;
 	bool fit_intercept = true;
 	BinomialLink link = BinomialLink::LOGIT;
 	uint32_t max_iterations = 100;
@@ -61,6 +64,7 @@ struct BinomialAggregateBindData : public FunctionData {
 		auto result = make_uniq<BinomialAggregateBindData>();
 		result->prior_opts = prior_opts;
 		result->glm_lambda = glm_lambda;
+		result->offset_column = offset_column;
 		result->fit_intercept = fit_intercept;
 		result->link = link;
 		result->max_iterations = max_iterations;
@@ -74,7 +78,7 @@ struct BinomialAggregateBindData : public FunctionData {
 		auto &o = other_p.Cast<BinomialAggregateBindData>();
 		return fit_intercept == o.fit_intercept && link == o.link && max_iterations == o.max_iterations &&
 		       tolerance == o.tolerance && compute_inference == o.compute_inference &&
-		       confidence_level == o.confidence_level;
+		       confidence_level == o.confidence_level && offset_column == o.offset_column;
 	}
 };
 
@@ -104,6 +108,7 @@ static LogicalType GetBinomialAggResultType(bool compute_inference) {
 	children.push_back(make_pair("n_observations", LogicalType::BIGINT));
 	children.push_back(make_pair("n_features", LogicalType::BIGINT));
 	children.push_back(make_pair("iterations", LogicalType::INTEGER));
+	children.push_back(make_pair("converged", LogicalType::BOOLEAN));
 
 	if (compute_inference) {
 		children.push_back(make_pair("std_errors", LogicalType::LIST(LogicalType::DOUBLE)));
@@ -144,6 +149,10 @@ static void BinomialAggUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 	auto x_list_data = ListVector::GetData(inputs[1]);
 	auto &x_child = ListVector::GetEntry(inputs[1]);
 	auto x_child_data = FlatVector::GetData<double>(x_child);
+	// A LIST containing NULLs is not itself NULL, so the list-level validity mask
+	// says nothing about the elements. Read the child mask too and pass NaN for a
+	// NULL element; the Rust side drops any row that is not finite throughout.
+	auto &x_child_validity = FlatVector::Validity(x_child);
 
 	UnifiedVectorFormat sdata;
 	state_vector.ToUnifiedFormat(count, sdata);
@@ -158,6 +167,7 @@ static void BinomialAggUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 		state.tolerance = bind_data.tolerance;
 		state.compute_inference = bind_data.compute_inference;
 		state.glm_lambda = bind_data.glm_lambda;
+		state.offset_column = bind_data.offset_column;
 		state.confidence_level = bind_data.confidence_level;
 
 		auto y_idx = y_data.sel->get_index(i);
@@ -189,8 +199,10 @@ static void BinomialAggUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 		state.y_values.push_back(y_val);
 
 		for (idx_t j = 0; j < n_features; j++) {
-			double x_val = x_child_data[list_entry.offset + j];
-			state.x_columns[j].push_back(x_val);
+			const idx_t child_idx = list_entry.offset + j;
+			state.x_columns[j].push_back(x_child_validity.RowIsValid(child_idx)
+			                                 ? x_child_data[child_idx]
+			                                 : std::numeric_limits<double>::quiet_NaN());
 		}
 	}
 }
@@ -226,6 +238,7 @@ static void BinomialAggCombine(Vector &source_vector, Vector &target_vector, Agg
 			target.compute_inference = source.compute_inference;
 			target.confidence_level = source.confidence_level;
 			target.glm_lambda = source.glm_lambda;
+			target.offset_column = source.offset_column;
 			continue;
 		}
 
@@ -294,6 +307,7 @@ static void BinomialAggFinalize(Vector &state_vector, AggregateInputData &aggr_i
 		options.compute_inference = state.compute_inference;
 		options.confidence_level = state.confidence_level;
 		options.lambda = state.glm_lambda;
+		options.offset_column = state.offset_column;
 		state.prior_state.Apply(options);
 
 		AnofoxGlmFitResultCore core_result;
@@ -325,6 +339,7 @@ static void BinomialAggFinalize(Vector &state_vector, AggregateInputData &aggr_i
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_observations;
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_features;
 		FlatVector::GetData<int32_t>(*struct_entries[struct_idx++])[result_idx] = core_result.iterations;
+		FlatVector::GetData<bool>(*struct_entries[struct_idx++])[result_idx] = core_result.converged;
 
 		if (state.compute_inference) {
 			SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.std_errors,
@@ -364,6 +379,9 @@ static unique_ptr<FunctionData> BinomialAggBind(ClientContext &context, Aggregat
 		}
 		if (opts.glm_lambda.has_value()) {
 			result->glm_lambda = opts.glm_lambda.value();
+		}
+		if (opts.offset_column.has_value()) {
+			result->offset_column = opts.offset_column.value();
 		}
 		if (opts.tolerance.has_value()) {
 			result->tolerance = opts.tolerance.value();

--- a/src/aggregate_functions/gamma_aggregate.cpp
+++ b/src/aggregate_functions/gamma_aggregate.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <vector>
 
 #include "duckdb.hpp"
@@ -30,10 +31,11 @@ struct GammaAggregateState {
 	double tolerance;
 	bool compute_inference;
 	double confidence_level;
+	idx_t offset_column;
 
 	GammaAggregateState()
 	    : n_features(0), initialized(false), fit_intercept(true), max_iterations(100), tolerance(1e-8),
-	      compute_inference(false), confidence_level(0.95) {
+	      compute_inference(false), confidence_level(0.95), offset_column(0) {
 	}
 
 	void Reset() {
@@ -53,6 +55,7 @@ struct GammaAggregateBindData : public FunctionData {
 	double tolerance = 1e-8;
 	bool compute_inference = false;
 	double confidence_level = 0.95;
+	idx_t offset_column = 0;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<GammaAggregateBindData>();
@@ -63,13 +66,15 @@ struct GammaAggregateBindData : public FunctionData {
 		result->tolerance = tolerance;
 		result->compute_inference = compute_inference;
 		result->confidence_level = confidence_level;
+		result->offset_column = offset_column;
 		return std::move(result);
 	}
 
 	bool Equals(const FunctionData &other_p) const override {
 		auto &o = other_p.Cast<GammaAggregateBindData>();
 		return fit_intercept == o.fit_intercept && max_iterations == o.max_iterations && tolerance == o.tolerance &&
-		       compute_inference == o.compute_inference && confidence_level == o.confidence_level;
+		       compute_inference == o.compute_inference && confidence_level == o.confidence_level &&
+		       offset_column == o.offset_column;
 	}
 };
 
@@ -86,6 +91,7 @@ static LogicalType GetGammaAggResultType(bool compute_inference) {
 	children.push_back(make_pair("n_observations", LogicalType::BIGINT));
 	children.push_back(make_pair("n_features", LogicalType::BIGINT));
 	children.push_back(make_pair("iterations", LogicalType::INTEGER));
+	children.push_back(make_pair("converged", LogicalType::BOOLEAN));
 
 	if (compute_inference) {
 		children.push_back(make_pair("std_errors", LogicalType::LIST(LogicalType::DOUBLE)));
@@ -126,6 +132,10 @@ static void GammaAggUpdate(Vector inputs[], AggregateInputData &aggr_input_data,
 	auto x_list_data = ListVector::GetData(inputs[1]);
 	auto &x_child = ListVector::GetEntry(inputs[1]);
 	auto x_child_data = FlatVector::GetData<double>(x_child);
+	// A LIST containing NULLs is not itself NULL, so the list-level validity mask
+	// says nothing about the elements. Read the child mask too and pass NaN for a
+	// NULL element; the Rust side drops any row that is not finite throughout.
+	auto &x_child_validity = FlatVector::Validity(x_child);
 
 	UnifiedVectorFormat sdata;
 	state_vector.ToUnifiedFormat(count, sdata);
@@ -140,6 +150,7 @@ static void GammaAggUpdate(Vector inputs[], AggregateInputData &aggr_input_data,
 		state.compute_inference = bind_data.compute_inference;
 		state.glm_lambda = bind_data.glm_lambda;
 		state.confidence_level = bind_data.confidence_level;
+		state.offset_column = bind_data.offset_column;
 
 		auto y_idx = y_data.sel->get_index(i);
 		if (!y_data.validity.RowIsValid(y_idx)) {
@@ -170,8 +181,10 @@ static void GammaAggUpdate(Vector inputs[], AggregateInputData &aggr_input_data,
 		state.y_values.push_back(y_val);
 
 		for (idx_t j = 0; j < n_features; j++) {
-			double x_val = x_child_data[list_entry.offset + j];
-			state.x_columns[j].push_back(x_val);
+			const idx_t child_idx = list_entry.offset + j;
+			state.x_columns[j].push_back(x_child_validity.RowIsValid(child_idx)
+			                                 ? x_child_data[child_idx]
+			                                 : std::numeric_limits<double>::quiet_NaN());
 		}
 	}
 }
@@ -206,6 +219,7 @@ static void GammaAggCombine(Vector &source_vector, Vector &target_vector, Aggreg
 			target.compute_inference = source.compute_inference;
 			target.confidence_level = source.confidence_level;
 			target.glm_lambda = source.glm_lambda;
+			target.offset_column = source.offset_column;
 			continue;
 		}
 
@@ -273,6 +287,7 @@ static void GammaAggFinalize(Vector &state_vector, AggregateInputData &aggr_inpu
 		options.compute_inference = state.compute_inference;
 		options.confidence_level = state.confidence_level;
 		options.lambda = state.glm_lambda;
+		options.offset_column = state.offset_column;
 		state.prior_state.Apply(options);
 
 		AnofoxGlmFitResultCore core_result;
@@ -302,6 +317,7 @@ static void GammaAggFinalize(Vector &state_vector, AggregateInputData &aggr_inpu
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_observations;
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_features;
 		FlatVector::GetData<int32_t>(*struct_entries[struct_idx++])[result_idx] = core_result.iterations;
+		FlatVector::GetData<bool>(*struct_entries[struct_idx++])[result_idx] = core_result.converged;
 
 		if (state.compute_inference) {
 			SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.std_errors,
@@ -344,6 +360,9 @@ static unique_ptr<FunctionData> GammaAggBind(ClientContext &context, AggregateFu
 		}
 		if (opts.tolerance.has_value()) {
 			result->tolerance = opts.tolerance.value();
+		}
+		if (opts.offset_column.has_value()) {
+			result->offset_column = opts.offset_column.value();
 		}
 	}
 

--- a/src/aggregate_functions/logistic_aggregate.cpp
+++ b/src/aggregate_functions/logistic_aggregate.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <vector>
 
 #include "duckdb.hpp"
@@ -32,10 +33,11 @@ struct LogisticAggregateState {
 	double tolerance;
 	bool compute_inference;
 	double confidence_level;
+	idx_t offset_column;
 
 	LogisticAggregateState()
 	    : n_features(0), initialized(false), fit_intercept(true), lambda(0.0), threshold(0.5), max_iterations(100),
-	      tolerance(1e-8), compute_inference(false), confidence_level(0.95) {
+	      tolerance(1e-8), compute_inference(false), confidence_level(0.95), offset_column(0) {
 	}
 
 	void Reset() {
@@ -56,6 +58,7 @@ struct LogisticAggregateBindData : public FunctionData {
 	double tolerance = 1e-8;
 	bool compute_inference = false;
 	double confidence_level = 0.95;
+	idx_t offset_column = 0;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<LogisticAggregateBindData>();
@@ -67,6 +70,7 @@ struct LogisticAggregateBindData : public FunctionData {
 		result->tolerance = tolerance;
 		result->compute_inference = compute_inference;
 		result->confidence_level = confidence_level;
+		result->offset_column = offset_column;
 		return std::move(result);
 	}
 
@@ -74,7 +78,8 @@ struct LogisticAggregateBindData : public FunctionData {
 		auto &o = other_p.Cast<LogisticAggregateBindData>();
 		return fit_intercept == o.fit_intercept && lambda == o.lambda && threshold == o.threshold &&
 		       max_iterations == o.max_iterations && tolerance == o.tolerance &&
-		       compute_inference == o.compute_inference && confidence_level == o.confidence_level;
+		       compute_inference == o.compute_inference && confidence_level == o.confidence_level &&
+		       offset_column == o.offset_column;
 	}
 };
 
@@ -92,6 +97,7 @@ static LogicalType GetLogisticAggResultType(bool compute_inference) {
 	children.push_back(make_pair("n_observations", LogicalType::BIGINT));
 	children.push_back(make_pair("n_features", LogicalType::BIGINT));
 	children.push_back(make_pair("iterations", LogicalType::INTEGER));
+	children.push_back(make_pair("converged", LogicalType::BOOLEAN));
 
 	if (compute_inference) {
 		children.push_back(make_pair("std_errors", LogicalType::LIST(LogicalType::DOUBLE)));
@@ -132,6 +138,10 @@ static void LogisticAggUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 	auto x_list_data = ListVector::GetData(inputs[1]);
 	auto &x_child = ListVector::GetEntry(inputs[1]);
 	auto x_child_data = FlatVector::GetData<double>(x_child);
+	// A LIST containing NULLs is not itself NULL, so the list-level validity mask
+	// says nothing about the elements. Read the child mask too and pass NaN for a
+	// NULL element; the Rust side drops any row that is not finite throughout.
+	auto &x_child_validity = FlatVector::Validity(x_child);
 
 	UnifiedVectorFormat sdata;
 	state_vector.ToUnifiedFormat(count, sdata);
@@ -147,6 +157,7 @@ static void LogisticAggUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 		state.tolerance = bind_data.tolerance;
 		state.compute_inference = bind_data.compute_inference;
 		state.confidence_level = bind_data.confidence_level;
+		state.offset_column = bind_data.offset_column;
 
 		auto y_idx = y_data.sel->get_index(i);
 		if (!y_data.validity.RowIsValid(y_idx)) {
@@ -176,8 +187,10 @@ static void LogisticAggUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 
 		state.y_values.push_back(y_val);
 		for (idx_t j = 0; j < n_features; j++) {
-			double x_val = x_child_data[list_entry.offset + j];
-			state.x_columns[j].push_back(x_val);
+			const idx_t child_idx = list_entry.offset + j;
+			state.x_columns[j].push_back(x_child_validity.RowIsValid(child_idx)
+			                                 ? x_child_data[child_idx]
+			                                 : std::numeric_limits<double>::quiet_NaN());
 		}
 	}
 }
@@ -213,6 +226,7 @@ static void LogisticAggCombine(Vector &source_vector, Vector &target_vector, Agg
 			target.tolerance = source.tolerance;
 			target.compute_inference = source.compute_inference;
 			target.confidence_level = source.confidence_level;
+			target.offset_column = source.offset_column;
 			continue;
 		}
 
@@ -281,6 +295,7 @@ static void LogisticAggFinalize(Vector &state_vector, AggregateInputData &aggr_i
 		options.threshold = state.threshold;
 		options.max_iterations = state.max_iterations;
 		options.tolerance = state.tolerance;
+		options.offset_column = state.offset_column;
 		state.prior_state.Apply(options);
 
 		AnofoxGlmFitResultCore core_result;
@@ -313,6 +328,7 @@ static void LogisticAggFinalize(Vector &state_vector, AggregateInputData &aggr_i
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_observations;
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_features;
 		FlatVector::GetData<int32_t>(*struct_entries[struct_idx++])[result_idx] = core_result.iterations;
+		FlatVector::GetData<bool>(*struct_entries[struct_idx++])[result_idx] = core_result.converged;
 
 		if (state.compute_inference) {
 			SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.std_errors,
@@ -358,6 +374,9 @@ static unique_ptr<FunctionData> LogisticAggBind(ClientContext &context, Aggregat
 		}
 		if (opts.threshold.has_value()) {
 			result->threshold = opts.threshold.value();
+		}
+		if (opts.offset_column.has_value()) {
+			result->offset_column = opts.offset_column.value();
 		}
 	}
 

--- a/src/aggregate_functions/negbinom_aggregate.cpp
+++ b/src/aggregate_functions/negbinom_aggregate.cpp
@@ -34,10 +34,11 @@ struct NegBinomAggregateState {
 	double tolerance;
 	bool compute_inference;
 	double confidence_level;
+	idx_t offset_column;
 
 	NegBinomAggregateState()
 	    : n_features(0), initialized(false), fit_intercept(true), max_iterations(100), tolerance(1e-8),
-	      compute_inference(false), confidence_level(0.95) {
+	      compute_inference(false), confidence_level(0.95), offset_column(0) {
 	}
 
 	void Reset() {
@@ -54,6 +55,7 @@ struct NegBinomAggregateBindData : public FunctionData {
 	//! Negative Binomial dispersion. NaN means "estimate from the data".
 	double theta = std::numeric_limits<double>::quiet_NaN();
 	double glm_lambda = 0.0;
+	idx_t offset_column = 0;
 	bool fit_intercept = true;
 	uint32_t max_iterations = 100;
 	double tolerance = 1e-8;
@@ -70,13 +72,15 @@ struct NegBinomAggregateBindData : public FunctionData {
 		result->tolerance = tolerance;
 		result->compute_inference = compute_inference;
 		result->confidence_level = confidence_level;
+		result->offset_column = offset_column;
 		return std::move(result);
 	}
 
 	bool Equals(const FunctionData &other_p) const override {
 		auto &o = other_p.Cast<NegBinomAggregateBindData>();
 		return fit_intercept == o.fit_intercept && max_iterations == o.max_iterations && tolerance == o.tolerance &&
-		       compute_inference == o.compute_inference && confidence_level == o.confidence_level;
+		       compute_inference == o.compute_inference && confidence_level == o.confidence_level &&
+		       offset_column == o.offset_column;
 	}
 };
 
@@ -93,6 +97,7 @@ static LogicalType GetNegBinomAggResultType(bool compute_inference) {
 	children.push_back(make_pair("n_observations", LogicalType::BIGINT));
 	children.push_back(make_pair("n_features", LogicalType::BIGINT));
 	children.push_back(make_pair("iterations", LogicalType::INTEGER));
+	children.push_back(make_pair("converged", LogicalType::BOOLEAN));
 
 	if (compute_inference) {
 		children.push_back(make_pair("std_errors", LogicalType::LIST(LogicalType::DOUBLE)));
@@ -133,6 +138,10 @@ static void NegBinomAggUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 	auto x_list_data = ListVector::GetData(inputs[1]);
 	auto &x_child = ListVector::GetEntry(inputs[1]);
 	auto x_child_data = FlatVector::GetData<double>(x_child);
+	// A LIST containing NULLs is not itself NULL, so the list-level validity mask
+	// says nothing about the elements. Read the child mask too and pass NaN for a
+	// NULL element; the Rust side drops any row that is not finite throughout.
+	auto &x_child_validity = FlatVector::Validity(x_child);
 
 	UnifiedVectorFormat sdata;
 	state_vector.ToUnifiedFormat(count, sdata);
@@ -147,6 +156,7 @@ static void NegBinomAggUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 		state.compute_inference = bind_data.compute_inference;
 		state.theta = bind_data.theta;
 		state.glm_lambda = bind_data.glm_lambda;
+		state.offset_column = bind_data.offset_column;
 		state.confidence_level = bind_data.confidence_level;
 
 		auto y_idx = y_data.sel->get_index(i);
@@ -178,8 +188,10 @@ static void NegBinomAggUpdate(Vector inputs[], AggregateInputData &aggr_input_da
 		state.y_values.push_back(y_val);
 
 		for (idx_t j = 0; j < n_features; j++) {
-			double x_val = x_child_data[list_entry.offset + j];
-			state.x_columns[j].push_back(x_val);
+			const idx_t child_idx = list_entry.offset + j;
+			state.x_columns[j].push_back(x_child_validity.RowIsValid(child_idx)
+			                                 ? x_child_data[child_idx]
+			                                 : std::numeric_limits<double>::quiet_NaN());
 		}
 	}
 }
@@ -215,6 +227,7 @@ static void NegBinomAggCombine(Vector &source_vector, Vector &target_vector, Agg
 			target.confidence_level = source.confidence_level;
 			target.glm_lambda = source.glm_lambda;
 			target.theta = source.theta;
+			target.offset_column = source.offset_column;
 			continue;
 		}
 
@@ -284,6 +297,7 @@ static void NegBinomAggFinalize(Vector &state_vector, AggregateInputData &aggr_i
 		options.lambda = state.glm_lambda;
 		// NaN on the wire means "estimate theta from the data".
 		options.alpha = state.theta;
+		options.offset_column = state.offset_column;
 		state.prior_state.Apply(options);
 
 		AnofoxGlmFitResultCore core_result;
@@ -314,6 +328,7 @@ static void NegBinomAggFinalize(Vector &state_vector, AggregateInputData &aggr_i
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_observations;
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_features;
 		FlatVector::GetData<int32_t>(*struct_entries[struct_idx++])[result_idx] = core_result.iterations;
+		FlatVector::GetData<bool>(*struct_entries[struct_idx++])[result_idx] = core_result.converged;
 
 		if (state.compute_inference) {
 			SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.std_errors,
@@ -356,6 +371,9 @@ static unique_ptr<FunctionData> NegBinomAggBind(ClientContext &context, Aggregat
 		}
 		if (opts.glm_lambda.has_value()) {
 			result->glm_lambda = opts.glm_lambda.value();
+		}
+		if (opts.offset_column.has_value()) {
+			result->offset_column = opts.offset_column.value();
 		}
 		if (opts.tolerance.has_value()) {
 			result->tolerance = opts.tolerance.value();

--- a/src/aggregate_functions/poisson_aggregate.cpp
+++ b/src/aggregate_functions/poisson_aggregate.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <vector>
 
 #include "duckdb.hpp"
@@ -31,10 +32,11 @@ struct PoissonAggregateState {
 	bool compute_inference;
 	double confidence_level;
 	double glm_lambda;
+	idx_t offset_column;
 
 	PoissonAggregateState()
 	    : n_features(0), initialized(false), fit_intercept(true), link(ANOFOX_POISSON_LINK_LOG), max_iterations(100),
-	      tolerance(1e-8), compute_inference(false), confidence_level(0.95), glm_lambda(0.0) {
+	      tolerance(1e-8), compute_inference(false), confidence_level(0.95), glm_lambda(0.0), offset_column(0) {
 	}
 
 	void Reset() {
@@ -58,6 +60,7 @@ struct PoissonAggregateBindData : public FunctionData {
 	bool compute_inference = false;
 	double confidence_level = 0.95;
 	double glm_lambda = 0.0;
+	idx_t offset_column = 0;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<PoissonAggregateBindData>();
@@ -69,6 +72,7 @@ struct PoissonAggregateBindData : public FunctionData {
 		result->compute_inference = compute_inference;
 		result->confidence_level = confidence_level;
 		result->glm_lambda = glm_lambda;
+		result->offset_column = offset_column;
 		return std::move(result);
 	}
 
@@ -76,7 +80,8 @@ struct PoissonAggregateBindData : public FunctionData {
 		auto &other = other_p.Cast<PoissonAggregateBindData>();
 		return fit_intercept == other.fit_intercept && link == other.link && max_iterations == other.max_iterations &&
 		       tolerance == other.tolerance && compute_inference == other.compute_inference &&
-		       confidence_level == other.confidence_level && glm_lambda == other.glm_lambda;
+		       confidence_level == other.confidence_level && glm_lambda == other.glm_lambda &&
+		       offset_column == other.offset_column;
 	}
 };
 
@@ -96,6 +101,7 @@ static LogicalType GetPoissonAggResultType(bool compute_inference) {
 	children.push_back(make_pair("n_observations", LogicalType::BIGINT));
 	children.push_back(make_pair("n_features", LogicalType::BIGINT));
 	children.push_back(make_pair("iterations", LogicalType::INTEGER));
+	children.push_back(make_pair("converged", LogicalType::BOOLEAN));
 
 	if (compute_inference) {
 		children.push_back(make_pair("std_errors", LogicalType::LIST(LogicalType::DOUBLE)));
@@ -153,6 +159,10 @@ static void PoissonAggUpdate(Vector inputs[], AggregateInputData &aggr_input_dat
 	auto x_list_data = ListVector::GetData(inputs[1]);
 	auto &x_child = ListVector::GetEntry(inputs[1]);
 	auto x_child_data = FlatVector::GetData<double>(x_child);
+	// A LIST containing NULLs is not itself NULL, so the list-level validity mask
+	// says nothing about the elements. Read the child mask too and pass NaN for a
+	// NULL element; the Rust side drops any row that is not finite throughout.
+	auto &x_child_validity = FlatVector::Validity(x_child);
 
 	UnifiedVectorFormat sdata;
 	state_vector.ToUnifiedFormat(count, sdata);
@@ -168,6 +178,7 @@ static void PoissonAggUpdate(Vector inputs[], AggregateInputData &aggr_input_dat
 		state.compute_inference = bind_data.compute_inference;
 		state.confidence_level = bind_data.confidence_level;
 		state.glm_lambda = bind_data.glm_lambda;
+		state.offset_column = bind_data.offset_column;
 
 		auto y_idx = y_data.sel->get_index(i);
 		if (!y_data.validity.RowIsValid(y_idx)) {
@@ -198,8 +209,10 @@ static void PoissonAggUpdate(Vector inputs[], AggregateInputData &aggr_input_dat
 		state.y_values.push_back(y_val);
 
 		for (idx_t j = 0; j < n_features; j++) {
-			double x_val = x_child_data[list_entry.offset + j];
-			state.x_columns[j].push_back(x_val);
+			const idx_t child_idx = list_entry.offset + j;
+			state.x_columns[j].push_back(x_child_validity.RowIsValid(child_idx)
+			                                 ? x_child_data[child_idx]
+			                                 : std::numeric_limits<double>::quiet_NaN());
 		}
 	}
 }
@@ -235,6 +248,7 @@ static void PoissonAggCombine(Vector &source_vector, Vector &target_vector, Aggr
 			target.compute_inference = source.compute_inference;
 			target.confidence_level = source.confidence_level;
 			target.glm_lambda = source.glm_lambda;
+			target.offset_column = source.offset_column;
 			continue;
 		}
 
@@ -304,6 +318,7 @@ static void PoissonAggFinalize(Vector &state_vector, AggregateInputData &aggr_in
 		options.compute_inference = state.compute_inference;
 		options.confidence_level = state.confidence_level;
 		options.lambda = state.glm_lambda;
+		options.offset_column = state.offset_column;
 		state.prior_state.Apply(options);
 
 		AnofoxGlmFitResultCore core_result;
@@ -332,6 +347,7 @@ static void PoissonAggFinalize(Vector &state_vector, AggregateInputData &aggr_in
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_observations;
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_features;
 		FlatVector::GetData<int32_t>(*struct_entries[struct_idx++])[result_idx] = core_result.iterations;
+		FlatVector::GetData<bool>(*struct_entries[struct_idx++])[result_idx] = core_result.converged;
 
 		if (state.compute_inference) {
 			SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.std_errors,
@@ -380,6 +396,9 @@ static unique_ptr<FunctionData> PoissonAggBind(ClientContext &context, Aggregate
 		}
 		if (opts.glm_lambda.has_value()) {
 			result->glm_lambda = opts.glm_lambda.value();
+		}
+		if (opts.offset_column.has_value()) {
+			result->offset_column = opts.offset_column.value();
 		}
 	}
 

--- a/src/aggregate_functions/tweedie_aggregate.cpp
+++ b/src/aggregate_functions/tweedie_aggregate.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <vector>
 
 #include "duckdb.hpp"
@@ -32,10 +33,11 @@ struct TweedieAggregateState {
 	double tolerance;
 	bool compute_inference;
 	double confidence_level;
+	idx_t offset_column;
 
 	TweedieAggregateState()
 	    : n_features(0), initialized(false), fit_intercept(true), power(1.5), max_iterations(100), tolerance(1e-8),
-	      compute_inference(false), confidence_level(0.95) {
+	      compute_inference(false), confidence_level(0.95), offset_column(0) {
 	}
 
 	void Reset() {
@@ -56,6 +58,7 @@ struct TweedieAggregateBindData : public FunctionData {
 	double tolerance = 1e-8;
 	bool compute_inference = false;
 	double confidence_level = 0.95;
+	idx_t offset_column = 0;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<TweedieAggregateBindData>();
@@ -67,6 +70,7 @@ struct TweedieAggregateBindData : public FunctionData {
 		result->tolerance = tolerance;
 		result->compute_inference = compute_inference;
 		result->confidence_level = confidence_level;
+		result->offset_column = offset_column;
 		return std::move(result);
 	}
 
@@ -74,7 +78,7 @@ struct TweedieAggregateBindData : public FunctionData {
 		auto &o = other_p.Cast<TweedieAggregateBindData>();
 		return fit_intercept == o.fit_intercept && power == o.power && max_iterations == o.max_iterations &&
 		       tolerance == o.tolerance && compute_inference == o.compute_inference &&
-		       confidence_level == o.confidence_level;
+		       confidence_level == o.confidence_level && offset_column == o.offset_column;
 	}
 };
 
@@ -91,6 +95,7 @@ static LogicalType GetTweedieAggResultType(bool compute_inference) {
 	children.push_back(make_pair("n_observations", LogicalType::BIGINT));
 	children.push_back(make_pair("n_features", LogicalType::BIGINT));
 	children.push_back(make_pair("iterations", LogicalType::INTEGER));
+	children.push_back(make_pair("converged", LogicalType::BOOLEAN));
 
 	if (compute_inference) {
 		children.push_back(make_pair("std_errors", LogicalType::LIST(LogicalType::DOUBLE)));
@@ -131,6 +136,10 @@ static void TweedieAggUpdate(Vector inputs[], AggregateInputData &aggr_input_dat
 	auto x_list_data = ListVector::GetData(inputs[1]);
 	auto &x_child = ListVector::GetEntry(inputs[1]);
 	auto x_child_data = FlatVector::GetData<double>(x_child);
+	// A LIST containing NULLs is not itself NULL, so the list-level validity mask
+	// says nothing about the elements. Read the child mask too and pass NaN for a
+	// NULL element; the Rust side drops any row that is not finite throughout.
+	auto &x_child_validity = FlatVector::Validity(x_child);
 
 	UnifiedVectorFormat sdata;
 	state_vector.ToUnifiedFormat(count, sdata);
@@ -146,6 +155,7 @@ static void TweedieAggUpdate(Vector inputs[], AggregateInputData &aggr_input_dat
 		state.compute_inference = bind_data.compute_inference;
 		state.glm_lambda = bind_data.glm_lambda;
 		state.confidence_level = bind_data.confidence_level;
+		state.offset_column = bind_data.offset_column;
 
 		auto y_idx = y_data.sel->get_index(i);
 		if (!y_data.validity.RowIsValid(y_idx)) {
@@ -176,8 +186,10 @@ static void TweedieAggUpdate(Vector inputs[], AggregateInputData &aggr_input_dat
 		state.y_values.push_back(y_val);
 
 		for (idx_t j = 0; j < n_features; j++) {
-			double x_val = x_child_data[list_entry.offset + j];
-			state.x_columns[j].push_back(x_val);
+			const idx_t child_idx = list_entry.offset + j;
+			state.x_columns[j].push_back(x_child_validity.RowIsValid(child_idx)
+			                                 ? x_child_data[child_idx]
+			                                 : std::numeric_limits<double>::quiet_NaN());
 		}
 	}
 }
@@ -213,6 +225,7 @@ static void TweedieAggCombine(Vector &source_vector, Vector &target_vector, Aggr
 			target.compute_inference = source.compute_inference;
 			target.confidence_level = source.confidence_level;
 			target.glm_lambda = source.glm_lambda;
+			target.offset_column = source.offset_column;
 			continue;
 		}
 
@@ -281,6 +294,7 @@ static void TweedieAggFinalize(Vector &state_vector, AggregateInputData &aggr_in
 		options.compute_inference = state.compute_inference;
 		options.confidence_level = state.confidence_level;
 		options.lambda = state.glm_lambda;
+		options.offset_column = state.offset_column;
 		state.prior_state.Apply(options);
 
 		AnofoxGlmFitResultCore core_result;
@@ -311,6 +325,7 @@ static void TweedieAggFinalize(Vector &state_vector, AggregateInputData &aggr_in
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_observations;
 		FlatVector::GetData<int64_t>(*struct_entries[struct_idx++])[result_idx] = core_result.n_features;
 		FlatVector::GetData<int32_t>(*struct_entries[struct_idx++])[result_idx] = core_result.iterations;
+		FlatVector::GetData<bool>(*struct_entries[struct_idx++])[result_idx] = core_result.converged;
 
 		if (state.compute_inference) {
 			SetListInResult(*struct_entries[struct_idx++], result_idx, inference_result.std_errors,
@@ -356,6 +371,9 @@ static unique_ptr<FunctionData> TweedieAggBind(ClientContext &context, Aggregate
 		}
 		if (opts.tweedie_power.has_value()) {
 			result->power = opts.tweedie_power.value();
+		}
+		if (opts.offset_column.has_value()) {
+			result->offset_column = opts.offset_column.value();
 		}
 	}
 

--- a/src/include/anofox_stats_ffi.h
+++ b/src/include/anofox_stats_ffi.h
@@ -735,6 +735,9 @@ typedef struct {
 	size_t n_features;
 	/** Number of iterations to converge */
 	uint32_t iterations;
+	/** Whether the IRLS solver reached the convergence tolerance. Appended last
+	    to preserve the ABI; every construction site must value-initialise. */
+	bool converged;
 } AnofoxGlmFitResultCore;
 
 /*
@@ -810,6 +813,9 @@ typedef struct {
 	size_t priors_len;
 	/** How to compute the coefficient covariance. */
 	AnofoxVcovType vcov;
+	/** 1-based index into x of an offset column (0 = none). Added to the linear
+	    predictor with coefficient fixed at 1 and dropped from the design. */
+	size_t offset_column;
 } AnofoxPoissonOptions;
 
 /**
@@ -835,6 +841,9 @@ typedef struct {
 	size_t priors_len;
 	/** How to compute the coefficient covariance. */
 	AnofoxVcovType vcov;
+	/** 1-based index into x of an offset column (0 = none). Added to the linear
+	    predictor with coefficient fixed at 1 and dropped from the design. */
+	size_t offset_column;
 } AnofoxBinomialOptions;
 
 /**
@@ -860,6 +869,9 @@ typedef struct {
 	size_t priors_len;
 	/** How to compute the coefficient covariance. */
 	AnofoxVcovType vcov;
+	/** 1-based index into x of an offset column (0 = none). Added to the linear
+	    predictor with coefficient fixed at 1 and dropped from the design. */
+	size_t offset_column;
 } AnofoxNegBinomialOptions;
 
 /**
@@ -885,6 +897,9 @@ typedef struct {
 	size_t priors_len;
 	/** How to compute the coefficient covariance. */
 	AnofoxVcovType vcov;
+	/** 1-based index into x of an offset column (0 = none). Added to the linear
+	    predictor with coefficient fixed at 1 and dropped from the design. */
+	size_t offset_column;
 } AnofoxTweedieOptions;
 
 /**
@@ -902,6 +917,9 @@ typedef struct {
 	size_t priors_len;
 	/** How to compute the coefficient covariance. */
 	AnofoxVcovType vcov;
+	/** 1-based index into x of an offset column (0 = none). Added to the linear
+	    predictor with coefficient fixed at 1 and dropped from the design. */
+	size_t offset_column;
 } AnofoxGammaOptions;
 
 /**
@@ -1002,6 +1020,9 @@ typedef struct {
 	size_t priors_len;
 	/** How to compute the coefficient covariance. */
 	AnofoxVcovType vcov;
+	/** 1-based index into x of an offset column (0 = none). Added to the linear
+	    predictor with coefficient fixed at 1 and dropped from the design. */
+	size_t offset_column;
 } AnofoxLogisticOptions;
 
 /**

--- a/test/sql/regression/test_glm_offset_converged.test
+++ b/test/sql/regression/test_glm_offset_converged.test
@@ -1,0 +1,148 @@
+# name: test/sql/regression/test_glm_offset_converged.test
+# description: GLM offset support (#110), NULL list elements (#110), and converged field (#111)
+# group: [regression]
+
+require anofox_statistics
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+# Counts (poisson / negbinom / tweedie)
+statement ok
+CREATE TABLE counts AS SELECT * FROM (VALUES
+    (1.0, 0.5, 2), (2.0, 1.0, 5), (3.0, 1.5, 12), (4.0, 2.0, 25), (5.0, 2.5, 45),
+    (6.0, 3.0, 80), (7.0, 3.5, 130), (8.0, 4.0, 200), (9.0, 4.5, 300), (10.0, 5.0, 450)
+) AS t(x1, x2, y);
+
+# Binary outcomes (binomial / logistic)
+statement ok
+CREATE TABLE binom_data AS SELECT * FROM (VALUES
+    (1.0, 0.5, 0), (2.0, 1.0, 0), (3.0, 1.5, 0), (4.0, 2.0, 0), (5.0, 2.5, 1),
+    (6.0, 3.0, 0), (7.0, 3.5, 1), (8.0, 4.0, 1), (9.0, 4.5, 1), (10.0, 5.0, 1)
+) AS t(x1, x2, y);
+
+# Strictly positive continuous (gamma)
+statement ok
+CREATE TABLE positive AS SELECT * FROM (VALUES
+    (1.0, 0.5, 1.2), (2.0, 1.0, 2.1), (3.0, 1.5, 3.4), (4.0, 2.0, 5.0), (5.0, 2.5, 7.1),
+    (6.0, 3.0, 9.0), (7.0, 3.5, 12.0), (8.0, 4.0, 15.0), (9.0, 4.5, 19.0), (10.0, 5.0, 24.0)
+) AS t(x1, x2, y);
+
+# =============================================================================
+# #111 - converged field is exposed on all six GLM aggregates
+# =============================================================================
+
+query I
+SELECT (poisson_fit_agg(y, [x1, x2])).converged FROM counts;
+----
+true
+
+query I
+SELECT (negbinom_fit_agg(y, [x1, x2])).converged FROM counts;
+----
+true
+
+query I
+SELECT (tweedie_fit_agg(y, [x1, x2])).converged FROM counts;
+----
+true
+
+query I
+SELECT (binomial_fit_agg(y, [x1, x2])).converged FROM binom_data;
+----
+true
+
+query I
+SELECT (logistic_fit_agg(y, [x1, x2])).converged FROM binom_data;
+----
+true
+
+query I
+SELECT (gamma_fit_agg(y, [x1, x2])).converged FROM positive;
+----
+true
+
+# converged is BOOLEAN in the returned STRUCT type
+query T
+SELECT typeof((poisson_fit_agg(y, [x1, x2])).converged) FROM counts;
+----
+BOOLEAN
+
+# =============================================================================
+# #110 - offset: the 1-based offset column is dropped from the design, so the
+# coefficient vector has one fewer entry than the feature list.
+# =============================================================================
+
+query II
+SELECT len((poisson_fit_agg(y, [x1, x2])).coefficients),
+       len((poisson_fit_agg(y, [x1, x2], {'offset': 2})).coefficients)
+FROM counts;
+----
+2	1
+
+query II
+SELECT len((negbinom_fit_agg(y, [x1, x2])).coefficients),
+       len((negbinom_fit_agg(y, [x1, x2], {'offset': 2})).coefficients)
+FROM counts;
+----
+2	1
+
+query II
+SELECT len((tweedie_fit_agg(y, [x1, x2])).coefficients),
+       len((tweedie_fit_agg(y, [x1, x2], {'offset': 2})).coefficients)
+FROM counts;
+----
+2	1
+
+query II
+SELECT len((binomial_fit_agg(y, [x1, x2])).coefficients),
+       len((binomial_fit_agg(y, [x1, x2], {'offset': 2})).coefficients)
+FROM binom_data;
+----
+2	1
+
+query II
+SELECT len((logistic_fit_agg(y, [x1, x2])).coefficients),
+       len((logistic_fit_agg(y, [x1, x2], {'offset': 2})).coefficients)
+FROM binom_data;
+----
+2	1
+
+query II
+SELECT len((gamma_fit_agg(y, [x1, x2])).coefficients),
+       len((gamma_fit_agg(y, [x1, x2], {'offset': 2})).coefficients)
+FROM positive;
+----
+2	1
+
+# n_features reflects the dropped offset column
+query I
+SELECT (poisson_fit_agg(y, [x1, x2], {'offset': 2})).n_features FROM counts;
+----
+1
+
+# An out-of-range offset index is rejected by the engine (row becomes NULL)
+query I
+SELECT (poisson_fit_agg(y, [x1, x2], {'offset': 9})) IS NULL FROM counts;
+----
+true
+
+# =============================================================================
+# #110 - NULL elements inside the x LIST drop the row rather than being read as
+# garbage. One of the five rows has a NULL feature, so n_observations is 4.
+# =============================================================================
+
+query I
+SELECT (poisson_fit_agg(y, [a, b])).n_observations FROM (VALUES
+    (2, 1.0, 1.0), (5, 2.0, 2.0), (12, 3.0, NULL), (25, 4.0, 4.0), (45, 5.0, 5.0)
+) AS v(y, a, b);
+----
+4
+
+query I
+SELECT (gamma_fit_agg(y, [a, b])).n_observations FROM (VALUES
+    (1.2, 1.0, 1.0), (2.1, 2.0, 2.0), (3.4, 3.0, NULL), (5.0, 4.0, 4.0), (7.1, 5.0, 5.0)
+) AS v(y, a, b);
+----
+4


### PR DESCRIPTION
Two follow-ups to the GLM aggregates from #108, applied uniformly across the six families (`poisson`, `binomial`, `negbinom`, `tweedie`, `gamma`, `logistic`).

## #110 — Uniform offset support and NULL list elements

**Offset.** A new `offset` MAP option (a 1-based index into `x`) is plumbed through the core GLM options, the FFI option structs + header, and each aggregate's state / bind-data / **combine** / update / finalize. The named column is removed from the design and added to the linear predictor with coefficient fixed at 1 — mirroring `glmm_fit_agg`. The value is used as-is (take logs upstream for the log link).

```sql
-- x = [promo, log_exposure]; log_exposure enters as an offset
SELECT poisson_fit_agg(events, [promo, log_exposure], {'offset': 2}) FROM t;
```

**NULL list elements.** A `LIST` containing NULLs is not itself NULL, so the element validity mask must be read explicitly. Each aggregate now reads the `x` child mask and passes `NaN` for a NULL element, which the Rust engine drops as non-finite — instead of reading whatever happened to be in that slot.

## #111 — `converged` in the GLM result STRUCT

`GlmFitResult::converged` already existed in core but never reached SQL. It is now appended to `AnofoxGlmFitResultCore` (Rust + hand-maintained header, ABI-appended and value-initialised at every construction site) and returned as `converged BOOLEAN` by all six aggregates, matching `aft_fit_agg` / `glmm_fit_agg`. **This is a deliberate, visible STRUCT schema change** (`SELECT (poisson_fit_agg(...)).*` gains a column).

## Tests & docs
- New `test/sql/regression/test_glm_offset_converged.test`: offset column-dropping, out-of-range rejection → NULL, NULL-row dropping, and `converged` across all six families.
- Full suite green: 2394 assertions / 97 cases; Rust 275 + 3.
- Docs: `offset` option row + a GlmFitResult Structure section (incl. `converged`) in `API_REFERENCE.md` and `poisson.md`.

## Deferred (intentionally out of scope)
- **Offset for `poisson_fit_predict`** — the predict path aligns coefficients to columns positionally in C++; honoring an offset there needs prediction-path realignment (the offset column is dropped from the fit), not mechanical plumbing. NULL handling there was already correct (#98).
- **NULL-element pattern in non-GLM aggregates** (ols/ridge/huber/wls/…) — 13 files share the raw read, but each needs per-core verification that NaN → row-drop is safe. #110 scopes this to the GLM aggregates.

Closes #110
Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788119998&installation_model_id=425457&pr_number=113&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F113&signature=8c6a6a34d12d7358f8a6b2364237a346f579a115517f058423afc8269a1f308e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->