### PR TITLE
fix(ci): satisfy clippy -D warnings on the code added in #108

### DIFF
--- a/crates/anofox-stats-core/src/models/aft.rs
+++ b/crates/anofox-stats-core/src/models/aft.rs
@@ -408,7 +408,7 @@ fn newton(
 
         let mut step = crate::models::glm_engine::normal_eq::solve_qr(&build_info(0.0), &g, 1e-12)?;
         let mut decrement: f64 = (0..n_params).map(|j| grad[j] * step[j]).sum();
-        if !(decrement > 0.0) || !decrement.is_finite() {
+        if !decrement.is_finite() || decrement <= 0.0 {
             let mut damping = 1e-3;
             for _ in 0..20 {
                 step = crate::models::glm_engine::normal_eq::solve_qr(
@@ -422,7 +422,7 @@ fn newton(
                 }
                 damping *= 10.0;
             }
-            if !(decrement > 0.0) || !decrement.is_finite() {
+            if !decrement.is_finite() || decrement <= 0.0 {
                 // Even heavy damping did not produce an ascent direction; fall back
                 // to steepest ascent, normalised so the line search starts sanely.
                 let gnorm = grad.iter().fold(0.0_f64, |m, v| m.max(v.abs())).max(1e-300);

--- a/crates/anofox-stats-core/src/models/eb_shrink.rs
+++ b/crates/anofox-stats-core/src/models/eb_shrink.rs
@@ -37,20 +37,11 @@ pub enum TauMethod {
 }
 
 /// Options for empirical-Bayes shrinkage.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct EbShrinkOptions {
     pub method: TauMethod,
     /// A fixed `tau^2` instead of estimating one. Overrides `method` when set.
     pub tau_squared: Option<f64>,
-}
-
-impl Default for EbShrinkOptions {
-    fn default() -> Self {
-        Self {
-            method: TauMethod::default(),
-            tau_squared: None,
-        }
-    }
 }
 
 /// One group's shrunken estimate.

--- a/crates/anofox-stats-core/src/models/glm.rs
+++ b/crates/anofox-stats-core/src/models/glm.rs
@@ -617,7 +617,7 @@ mod tests {
         let fit = fit_poisson(&y, &x, &PoissonOptions::default()).unwrap();
         assert!((fit.core.intercept.unwrap() - 0.783_761_952_889_341_5).abs() < 1e-7);
         assert!((fit.core.coefficients[0] - 0.241_563_412_876_373_3).abs() < 1e-7);
-        assert!((fit.core.coefficients[1] + 0.128_771_260_171_794_0).abs() < 1e-7);
+        assert!((fit.core.coefficients[1] + 0.128_771_260_171_794).abs() < 1e-7);
     }
 
     #[test]
@@ -627,7 +627,7 @@ mod tests {
         let y: Vec<f64> = (0..n)
             .map(|i| f64::from(u8::from(0.8 * xs[i] + ((i % 3) as f64 - 1.0) * 0.5 > 0.0)))
             .collect();
-        let fit = fit_logistic(&y, &vec![xs], &LogisticOptions::default()).unwrap();
+        let fit = fit_logistic(&y, &[xs], &LogisticOptions::default()).unwrap();
         assert!((0.0..=1.0).contains(&fit.accuracy));
         assert!(fit.accuracy > 0.5, "accuracy {}", fit.accuracy);
     }

--- a/crates/anofox-stats-core/src/models/glm_engine/design.rs
+++ b/crates/anofox-stats-core/src/models/glm_engine/design.rs
@@ -446,7 +446,7 @@ mod tests {
         })
         .unwrap();
 
-        let err = d.build_penalty(&vec![PriorSpec::flat(); 7], 0.0);
+        let err = d.build_penalty(&[PriorSpec::flat(); 7], 0.0);
         assert!(matches!(err, Err(StatsError::InvalidInput(_))));
     }
 

--- a/crates/anofox-stats-core/src/models/glm_engine/loglik.rs
+++ b/crates/anofox-stats-core/src/models/glm_engine/loglik.rs
@@ -190,7 +190,7 @@ mod tests {
     fn poisson_matches_dpois() {
         // R: dpois(3, lambda = 2.5, log = TRUE) = -1.542887273605590
         let ll = unit_log_likelihood(LogLikKind::Poisson, 3.0, 2.5);
-        assert!((ll - (-1.542_887_273_605_590)).abs() < 1e-12, "got {ll}");
+        assert!((ll - (-1.542_887_273_605_59)).abs() < 1e-12, "got {ll}");
     }
 
     #[test]

--- a/crates/anofox-stats-core/src/models/glm_engine/parity.rs
+++ b/crates/anofox-stats-core/src/models/glm_engine/parity.rs
@@ -376,7 +376,7 @@ fn poisson_single_feature_matches_the_reference() {
         0.792_438_587_563_215_5,
         REF_TOL,
     );
-    assert_close("slope", fit.irls.beta[1], 0.238_180_118_325_312_0, REF_TOL);
+    assert_close("slope", fit.irls.beta[1], 0.238_180_118_325_312, REF_TOL);
     assert_close(
         "deviance",
         fit.irls.deviance,
@@ -426,7 +426,7 @@ fn poisson_two_feature_matches_the_reference() {
         REF_TOL,
     );
     assert_close("x1", fit.irls.beta[1], 0.241_563_412_876_373_3, REF_TOL);
-    assert_close("x2", fit.irls.beta[2], -0.128_771_260_171_794_0, REF_TOL);
+    assert_close("x2", fit.irls.beta[2], -0.128_771_260_171_794, REF_TOL);
     assert_close(
         "deviance",
         fit.irls.deviance,
@@ -445,7 +445,7 @@ fn poisson_two_feature_matches_the_reference() {
     assert_close(
         "intercept se",
         inf.std_errors[0],
-        0.151_817_171_836_096_0,
+        0.151_817_171_836_096,
         REF_TOL,
     );
     assert_close("x1 se", inf.std_errors[1], 0.078_215_310_636_067_5, REF_TOL);
@@ -537,7 +537,7 @@ fn tweedie_single_feature_matches_the_reference() {
         0.545_111_433_395_903_3,
         REF_TOL,
     );
-    assert_close("slope", fit.irls.beta[1], 0.233_128_099_664_133_0, REF_TOL);
+    assert_close("slope", fit.irls.beta[1], 0.233_128_099_664_133, REF_TOL);
     assert_close(
         "deviance",
         fit.irls.deviance,
@@ -584,7 +584,7 @@ fn negbinomial_single_feature_matches_the_reference() {
     assert_close(
         "slope se",
         inf.std_errors[1],
-        0.119_889_845_294_418_0,
+        0.119_889_845_294_418,
         REF_TOL,
     );
 }
@@ -738,7 +738,7 @@ fn constant_columns_are_dropped_and_reported_as_nan() {
     assert_eq!(res.coefficients.len(), 3);
     assert!(res.coefficients[0].is_nan(), "constant column must be NaN");
     assert_close("x1", res.coefficients[1], 0.241_563_412_876_373_3, REF_TOL);
-    assert_close("x2", res.coefficients[2], -0.128_771_260_171_794_0, REF_TOL);
+    assert_close("x2", res.coefficients[2], -0.128_771_260_171_794, REF_TOL);
 
     let inf = fit.to_glm_inference().unwrap();
     assert!(inf.std_errors[0].is_nan());

--- a/crates/anofox-stats-core/src/models/glmm.rs
+++ b/crates/anofox-stats-core/src/models/glmm.rs
@@ -297,7 +297,6 @@ pub fn fit_glmm(
             &yv,
             &groups,
             n_groups,
-            &group_sizes,
             offset.as_deref(),
             log_theta.exp(),
         ) {
@@ -315,7 +314,6 @@ pub fn fit_glmm(
         &yv,
         &groups,
         n_groups,
-        &group_sizes,
         offset.as_deref(),
         theta,
     )?;
@@ -440,7 +438,6 @@ fn inner_fit(
     y: &[f64],
     groups: &[usize],
     n_groups: usize,
-    group_sizes: &[usize],
     offset: Option<&[f64]>,
     theta: f64,
 ) -> StatsResult<InnerFit> {
@@ -668,8 +665,8 @@ fn inner_fit(
     // Joint posterior precision of b_g is (Z'WZ)_g / phi + 1 / sigma_b^2, which is
     // (zwz_g + lambda) / phi. Diagonal, so the determinant is a sum of logs.
     let mut log_det = 0.0;
-    for g in 0..n_groups {
-        let d = (zwz[g] + lambda) / phi;
+    for &z in zwz.iter().take(n_groups) {
+        let d = (z + lambda) / phi;
         if d > 0.0 {
             log_det += d.ln();
         }
@@ -865,7 +862,7 @@ mod tests {
                 let x = (j % 4) as f64;
                 y.push((0.5 + 0.3 * x + b).exp().round());
                 xs.push(x);
-                g.push(gi as i32);
+                g.push(gi);
             }
         }
         let opts = GlmmOptions {
@@ -873,7 +870,7 @@ mod tests {
             compute_inference: true,
             ..Default::default()
         };
-        let fit = fit_glmm(&y, &vec![xs], &g, &opts).unwrap();
+        let fit = fit_glmm(&y, &[xs], &g, &opts).unwrap();
 
         assert!(
             (fit.coefficients[0] - 0.3).abs() < 0.1,

--- a/crates/anofox-stats-ffi/src/lib.rs
+++ b/crates/anofox-stats-ffi/src/lib.rs
@@ -7290,7 +7290,7 @@ unsafe fn alloc_f64(values: &[f64]) -> *mut f64 {
     if values.is_empty() {
         return std::ptr::null_mut();
     }
-    let ptr = libc::malloc(std::mem::size_of::<f64>() * values.len()) as *mut f64;
+    let ptr = libc::malloc(std::mem::size_of_val(values)) as *mut f64;
     if !ptr.is_null() {
         std::ptr::copy_nonoverlapping(values.as_ptr(), ptr, values.len());
     }
@@ -7622,7 +7622,7 @@ unsafe fn alloc_i32(values: &[i32]) -> *mut i32 {
     if values.is_empty() {
         return std::ptr::null_mut();
     }
-    let ptr = libc::malloc(std::mem::size_of::<i32>() * values.len()) as *mut i32;
+    let ptr = libc::malloc(std::mem::size_of_val(values)) as *mut i32;
     if !ptr.is_null() {
         std::ptr::copy_nonoverlapping(values.as_ptr(), ptr, values.len());
     }
@@ -7633,7 +7633,7 @@ unsafe fn alloc_i64(values: &[i64]) -> *mut i64 {
     if values.is_empty() {
         return std::ptr::null_mut();
     }
-    let ptr = libc::malloc(std::mem::size_of::<i64>() * values.len()) as *mut i64;
+    let ptr = libc::malloc(std::mem::size_of_val(values)) as *mut i64;
     if !ptr.is_null() {
         std::ptr::copy_nonoverlapping(values.as_ptr(), ptr, values.len());
     }

--- a/crates/anofox-stats-ffi/src/types.rs
+++ b/crates/anofox-stats-ffi/src/types.rs
@@ -645,20 +645,15 @@ impl Default for PriorSpecFFI {
 // every field that follows it. Harmless while such a field sits last in a
 // struct, fatal when it sits first (AftOptionsFFI::dist).
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum VcovTypeFFI {
     /// `(X'WX + P)^-1`, the curvature of the log posterior at the mode.
+    #[default]
     Laplace = 0,
     /// `(X'WX + P)^-1 X'WX (X'WX + P)^-1`.
     Sandwich = 1,
     /// `(X'WX)^-1`, ignoring the penalty.
     Naive = 2,
-}
-
-impl Default for VcovTypeFFI {
-    fn default() -> Self {
-        VcovTypeFFI::Laplace
-    }
 }
 
 /// Prior and covariance settings carried by every GLM options struct.
@@ -2253,18 +2248,13 @@ impl Default for LmDynamicFitResultFFI {
 // every field that follows it. Harmless while such a field sits last in a
 // struct, fatal when it sits first (AftOptionsFFI::dist).
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AftDistributionFFI {
+    #[default]
     Weibull = 0,
     LogNormal = 1,
     LogLogistic = 2,
     Exponential = 3,
-}
-
-impl Default for AftDistributionFFI {
-    fn default() -> Self {
-        AftDistributionFFI::Weibull
-    }
 }
 
 /// Options for an AFT fit. Flat POD, like every other options struct here.
@@ -2392,17 +2382,12 @@ mod abi_tests {
 
 /// Between-group variance estimator.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TauMethodFFI {
+    #[default]
     DerSimonianLaird = 0,
     /// Complete pooling.
     None = 1,
-}
-
-impl Default for TauMethodFFI {
-    fn default() -> Self {
-        TauMethodFFI::DerSimonianLaird
-    }
 }
 
 /// Options for empirical-Bayes shrinkage.
@@ -2446,20 +2431,15 @@ pub struct EbShrinkResultFFI {
 
 /// Response family for a mixed-effects fit.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum GlmmFamilyFFI {
+    #[default]
     Gaussian = 0,
     Poisson = 1,
     Binomial = 2,
     NegativeBinomial = 3,
     Gamma = 4,
     Tweedie = 5,
-}
-
-impl Default for GlmmFamilyFFI {
-    fn default() -> Self {
-        GlmmFamilyFFI::Gaussian
-    }
 }
 
 /// Options for a mixed-effects fit.


### PR DESCRIPTION
**`main` has been red since #108 merged, and it's my fault.**

CI's "Build and test Rust components" job runs:

```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo build --release
cargo test --all-features
```

#108 was verified with `cargo test` and `cargo fmt` but **never with clippy**. Result: 17 clippy errors, all in code that PR introduced.

This blocks **#112 and #113** — both inherit the failing job from `main`, so neither can go green until this lands. Neither PR is at fault.

## Substantive fixes

- **`glmm.rs`** — `inner_fit` took a `group_sizes` parameter it never read; the sizes are recomputed as `zwz` inside the loop. Removed the parameter rather than underscoring it, since callers were passing a value that had no effect.
- **`aft.rs`** — `!(decrement > 0.0)` on a partially ordered type, twice. Rewritten as `!decrement.is_finite() || decrement <= 0.0`, which also makes the NaN case explicit instead of leaning on negation semantics.
- **`glmm.rs`** — log-determinant loop indexed `zwz` by a counter; now iterates.
- **`eb_shrink.rs` + four FFI enums** — hand-written `Default` impls that are derivable. I verified the derived `#[default]` sits on the same variant each manual impl returned (`Laplace` / `Weibull` / `DerSimonianLaird` / `Gaussian`). These feed FFI defaults, so a silent change here would matter.

## Mechanical fixes

Applied via `cargo clippy --fix` so the values couldn't be mistyped: excessive float precision on reference constants, three `vec![]` → array, three manual slice-size calculations.

The constant edits are **trailing-zero spelling only** — `0.128_771_260_171_794_0` → `0.128_771_260_171_794`. Every f64 value is bit-identical, which is the thing that matters given these are parity reference constants.

## Verification

Full CI sequence green locally:

| Step | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --all-targets --all-features -- -D warnings` | pass |
| `cargo build --release` | pass |
| `cargo test --all-features` | 275 core + 3 FFI |
| `make release` + `unittest "test/*"` | 2368 assertions / 96 cases |

## Follow-up worth considering

Clippy isn't in any local gate — `scripts/check_code_quality.sh` and the pre-commit hooks don't run it, which is exactly how this got through. Adding `cargo clippy --all-targets --all-features -- -D warnings` there would catch the next one before CI does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788184233&installation_model_id=425457&pr_number=115&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F115&signature=20aab171ac256c2c804db04e142fc9f15835c5048ed1348ad5eeee7183563186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->