### PR TITLE
chore: bump anofox-regression 0.5.7 -> 0.5.13 (fixes #114)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anofox-regression"
-version = "0.5.7"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83196428371fd4134cca085693bfab52e1e63799d67bb9f7ac633b3b445c97ea"
+checksum = "bd8869f036d28d7848f7c5a0ccbdb2c4e64d1e586f8ccdfa55dd810a8b30ee8b"
 dependencies = [
  "argmin",
  "argmin-math",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ authors = ["Simon M"]
 repository = "https://github.com/DataZooDE/anofox-statistics"
 
 [workspace.dependencies]
-anofox-regression = "0.5.7"
+anofox-regression = "0.5.13"
 anofox-tests = { package = "anofox-statistics", version = "0.4.2" }
 # faer: disable default features (which include rayon) - DuckDB handles parallelization
 faer = { version = "0.23", default-features = false, features = ["std", "linalg"] }

--- a/crates/anofox-stats-core/src/models/glm_engine/normal_eq.rs
+++ b/crates/anofox-stats-core/src/models/glm_engine/normal_eq.rs
@@ -185,12 +185,13 @@ pub fn solve_weighted_ls_qr(
     // Undo the column pivoting. `X * P = Q * R`, so the i-th pivoted column is the
     // original column `fwd[i]` and therefore `beta[fwd[i]] = beta_perm[i]`.
     //
-    // Note this uses the *forward* array. Upstream indexes with
+    // Note this uses the *forward* array. Upstream historically indexed with
     // `perm.inverse().arrays().0` instead, which happens to agree whenever the
     // pivot order is an involution (any 2-column design, and 3-column orders like
-    // [2,1,0]) but silently rotates the coefficient vector for a genuine cycle such
-    // as [1,2,0]. That is why upstream diverges on ordinary 3-column fixtures — see
-    // `permutation_is_undone_for_a_three_cycle` below.
+    // [2,1,0]) but silently rotated the coefficient vector for a genuine cycle such
+    // as [1,2,0] — see `permutation_is_undone_for_a_three_cycle` below. That defect
+    // (anofox-regression#28) was fixed upstream in 0.5.13; this engine always used
+    // the forward array and is unaffected either way.
     let mut beta: Col<f64> = Col::zeros(p);
     let fwd = perm.arrays().0;
     for i in 0..p {

--- a/crates/anofox-stats-core/src/models/glm_engine/parity.rs
+++ b/crates/anofox-stats-core/src/models/glm_engine/parity.rs
@@ -593,10 +593,14 @@ fn negbinomial_single_feature_matches_the_reference() {
 // Pins for the two upstream defects.
 // ---------------------------------------------------------------------------
 
-/// Upstream's inverted back-permutation. If a future dependency bump fixes this,
-/// the test fails loudly and the workaround notes above can be removed.
+/// Upstream's inverted back-permutation (anofox-regression#28) rotated the
+/// coefficient vector for any non-involutive pivot order, i.e. essentially every
+/// 3+-column design. It was fixed in 0.5.13 (the pivoted-QR solvers now use the
+/// forward `perm.arrays().0`). This pins that fix: upstream must fit a 3-column
+/// design and agree with the engine, whose local unpermute in `normal_eq.rs` was
+/// always correct. If a future bump reintroduces the defect, this fails loudly.
 #[test]
-fn upstream_cannot_fit_a_three_column_design_but_the_engine_can() {
+fn upstream_and_engine_agree_on_a_three_column_design() {
     let (y, x) = count_2f();
     let (y_col, x_mat) = to_faer(&y, &x);
 
@@ -605,12 +609,9 @@ fn upstream_cannot_fit_a_three_column_design_but_the_engine_can() {
         .max_iterations(100)
         .tolerance(1e-8)
         .build()
-        .fit(&x_mat, &y_col);
-    assert!(
-        upstream.is_err(),
-        "upstream unexpectedly fitted a 3-column design — the pivot back-permutation \
-         defect may have been fixed; re-check the workaround in normal_eq.rs"
-    );
+        .fit(&x_mat, &y_col)
+        .expect("upstream must fit a 3-column design (pivot unpermute fixed in 0.5.13)");
+    let up = upstream.result();
 
     let fit = fit(
         &PoissonFamily::log(),
@@ -619,8 +620,13 @@ fn upstream_cannot_fit_a_three_column_design_but_the_engine_can() {
         &poisson_opts(false),
         DispersionRule::PearsonFlooredAtOne,
         |_| LogLikKind::Poisson,
-    );
-    assert!(fit.is_ok(), "the engine must handle 3-column designs");
+    )
+    .expect("the engine must handle 3-column designs");
+
+    // Engine beta is [intercept, x1, x2]; upstream splits intercept from coefficients.
+    assert_close("intercept", fit.irls.beta[0], up.intercept.unwrap(), TOL);
+    assert_close("x1", fit.irls.beta[1], up.coefficients[0], TOL);
+    assert_close("x2", fit.irls.beta[2], up.coefficients[1], TOL);
 }
 
 /// A perfectly-fitting model drives the deviance to ~1e-14, where a purely

--- a/test/sql/regression/test_bls_nnls_pivot.test
+++ b/test/sql/regression/test_bls_nnls_pivot.test
@@ -1,0 +1,45 @@
+# name: test/sql/regression/test_bls_nnls_pivot.test
+# description: BLS/NNLS recover correct (un-rotated) coefficients for a non-involutive QR pivot order (#114 / anofox-regression#28, fixed upstream in 0.5.13)
+# group: [regression]
+
+require anofox_statistics
+
+# y = 7*c0 + 2*c1 + 0.5*c2, all non-negative so NNLS == OLS. Column norms are
+# chosen so the column-pivoted QR order is a genuine 3-cycle — the case the
+# upstream inverse-permutation unpermute rotated. Truth is [7.0, 2.0, 0.5].
+statement ok
+CREATE TABLE piv AS
+SELECT ((i % 4) * 0.001 + 0.001)              AS c0,
+       (((i * 3) % 5) * 1000.0 + 5.0)         AS c1,
+       (((i * 7) % 6) * 10.0 + 1.0)           AS c2,
+       7.0 * ((i % 4) * 0.001 + 0.001)
+         + 2.0 * (((i * 3) % 5) * 1000.0 + 5.0)
+         + 0.5 * (((i * 7) % 6) * 10.0 + 1.0)  AS y
+FROM range(0, 12) s(i);
+
+# NNLS recovers [7, 2, 0.5], not a rotation of it
+query III
+SELECT round((nnls_fit_agg(y, [c0, c1, c2])).coefficients[1], 3),
+       round((nnls_fit_agg(y, [c0, c1, c2])).coefficients[2], 3),
+       round((nnls_fit_agg(y, [c0, c1, c2])).coefficients[3], 3)
+FROM piv;
+----
+7.0	2.0	0.5
+
+# BLS with default (non-negative) bounds matches
+query III
+SELECT round((bls_fit_agg(y, [c0, c1, c2])).coefficients[1], 3),
+       round((bls_fit_agg(y, [c0, c1, c2])).coefficients[2], 3),
+       round((bls_fit_agg(y, [c0, c1, c2])).coefficients[3], 3)
+FROM piv;
+----
+7.0	2.0	0.5
+
+# ... and agrees with OLS on this non-negative design
+query III
+SELECT round((ols_fit_agg(y, [c0, c1, c2])).coefficients[1], 3),
+       round((ols_fit_agg(y, [c0, c1, c2])).coefficients[2], 3),
+       round((ols_fit_agg(y, [c0, c1, c2])).coefficients[3], 3)
+FROM piv;
+----
+7.0	2.0	0.5


### PR DESCRIPTION
Bumps the upstream `anofox-regression` crate to **0.5.13**, which fixes the column-pivoted QR back-permutation bug (`anofox-regression#28`). `anofox-statistics` (`anofox-tests`) is already at its latest 0.4.2.

Replaces #112 (which bumped only to 0.5.12 and did **not** fix the pivot bug).

## Fixes #114

`nnls_fit_agg` / `bls_fit_agg` call `BlsRegressor` directly, which unpermuted the pivoted-QR result with the **inverse** permutation — correct only for involutive pivot orders (≤2 columns), silently **rotated** for a genuine cycle (essentially every 3+-column design). 0.5.13 switches the five affected solvers (`bls`, `poisson`, `binomial`, `negative_binomial`, `tweedie`) to the forward `perm.arrays().0`.

Before → after on the issue's 3-cycle reproducer (truth `[7, 2, 0.5]`):

```
nnls  [0.5, 7.0, 2.0]   -->   [7.0, 2.0, 0.5]
bls   [0.5, 7.0, 2.0]   -->   [7.0, 2.0, 0.5]
```

## Changes beyond the version bump
- **`parity.rs`** — the `upstream_cannot_fit_a_three_column_design_but_the_engine_can` pin asserted upstream *fails* on a 3-column design; it was written to trip loudly once the bug was fixed. Reworked into `upstream_and_engine_agree_on_a_three_column_design`, which asserts upstream now succeeds and matches the engine.
- **`normal_eq.rs`** — refreshed the comment (the defect is fixed upstream in 0.5.13; the local engine always used the correct forward array).
- **`test/sql/regression/test_bls_nnls_pivot.test`** — new 3-cycle fixture asserting `nnls`/`bls`/`ols` all recover `[7, 2, 0.5]`.

## Verification
- `cargo test` — 275 core + 3 FFI ABI pass.
- Full SQL suite — 2378 assertions / 97 cases, incl. the new pivot test.
- The `#114` reproducer now returns the correct coefficients.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788200598&installation_model_id=425457&pr_number=116&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F116&signature=d50fb8f654f16f9d5136eb2802536fd346963f522b75c7a32411a2f9993ebb19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->