### PR TITLE
feat(glmm): random slopes and crossed/nested factors via upstream GlmmRegressor (#109)

### DIFF
--- a/crates/anofox-stats-core/src/models/glmm.rs
+++ b/crates/anofox-stats-core/src/models/glmm.rs
@@ -1,39 +1,32 @@
-//! Mixed-effects GLMs: a random intercept over one grouping factor.
+//! Mixed-effects GLMs (GLMM):
 //!
 //! ```text
-//!   g(mu_ij) = x_ij' beta + b_j ,   b_j ~ N(0, sigma_b^2)
+//!   g(mu_ij) = x_ij' beta + z_ij' b_j ,   b_j ~ N(0, Sigma)
 //! ```
 //!
-//! This is where the prior work in [`crate::models::glm_engine`] pays off. A
-//! Gaussian random effect and a Gaussian prior are the same object — a quadratic
-//! precision block in the penalized normal equations — so the inner loop here is
-//! penalized IRLS over `[X | Z]` with a zero block on `X` and
-//! `sigma_e^2 / sigma_b^2` on `Z`. Those are Henderson's mixed-model equations.
+//! The solver itself lives upstream in [`anofox_regression::solvers::GlmmRegressor`]
+//! (Henderson's mixed-model equations with a block-per-group elimination, the
+//! variance components profiled by golden-section for a random intercept and by
+//! Nelder–Mead once slopes give an unstructured `Sigma`). This module is the thin
+//! marshalling layer: it validates and filters rows, compacts the grouping factors,
+//! hands dense matrices to the solver, and reshapes the fit into [`GlmmResult`].
 //!
-//! Two things stop this from being a literal call into the dense GLM path:
+//! Supported here:
 //!
-//! * `Z` is a group-indicator matrix with one column per group. For thousands of
-//!   SKUs a dense `[X | Z]` is hopeless, so the normal equations are accumulated
-//!   block-wise: the `Z'WZ` block is *diagonal*, and `X'WZ` is one column per
-//!   group. `Z` is never materialized. This is the reason
-//!   [`crate::models::glm_engine::normal_eq`] exists as its own seam.
-//! * `sigma_b^2` has to be estimated. The outer loop maximizes the
-//!   Laplace-approximated log marginal likelihood by bounded Brent search, over
-//!   the *ratio* `theta = sigma_b / sigma_e` rather than `sigma_b` itself. The
-//!   mixed-model penalty is `sigma_e^2 / sigma_b^2`, so it is scale-free;
-//!   searching over `sigma_b` alone makes the objective depend on the units of
-//!   the response. `lme4` profiles over the same ratio.
+//! * A random intercept over one grouping factor ([`fit_glmm`]).
+//! * Random slopes on named feature columns, with an unstructured covariance
+//!   ([`GlmmOptions::random_slopes`]).
+//! * Several crossed / nested random-intercept factors ([`fit_glmm_crossed`]).
 //!
-//! Scope is deliberately one random intercept over one grouping factor. Random
-//! slopes need an unstructured `Lambda(theta)` and a multi-dimensional outer
-//! optimization; they are a follow-up.
+//! Families are limited to gaussian, poisson and binomial; NegBinomial/Gamma/
+//! Tweedie mixed-effects, an offset, per-group BLUP standard errors, and random
+//! slopes combined with multiple factors are tracked upstream (anofox-regression#29)
+//! and return a clear error until then.
 
 use crate::errors::{StatsError, StatsResult};
-use crate::models::glm_engine::loglik::{self, LogLikKind};
-use anofox_regression::core::{
-    BinomialFamily, GlmFamily, NegativeBinomialFamily, PoissonFamily, TweedieFamily,
-};
+use anofox_regression::solvers::GlmmRegressor;
 use faer::{Col, Mat};
+use statrs::distribution::{ContinuousCDF, Normal};
 
 /// Which response family the mixed model uses.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -65,37 +58,6 @@ impl GlmmFamily {
             _ => None,
         }
     }
-
-    fn is_gaussian(&self) -> bool {
-        matches!(self, GlmmFamily::Gaussian)
-    }
-
-    /// The upstream family object driving the IRLS weights, or `None` for
-    /// Gaussian, which needs no iteration.
-    fn upstream(&self) -> Option<Box<dyn GlmFamily>> {
-        match *self {
-            GlmmFamily::Gaussian => None,
-            GlmmFamily::Poisson => Some(Box::new(PoissonFamily::log())),
-            GlmmFamily::Binomial => Some(Box::new(BinomialFamily::logistic())),
-            GlmmFamily::NegativeBinomial { theta } => {
-                Some(Box::new(NegativeBinomialFamily::new(theta)))
-            }
-            GlmmFamily::Gamma => Some(Box::new(TweedieFamily::new(2.0, 0.0))),
-            GlmmFamily::Tweedie { power } => Some(Box::new(TweedieFamily::new(power, 0.0))),
-        }
-    }
-
-    fn loglik_kind(&self, dispersion: f64) -> LogLikKind {
-        match *self {
-            // Handled separately; never reached for Gaussian.
-            GlmmFamily::Gaussian => LogLikKind::Poisson,
-            GlmmFamily::Poisson => LogLikKind::Poisson,
-            GlmmFamily::Binomial => LogLikKind::Binomial,
-            GlmmFamily::NegativeBinomial { theta } => LogLikKind::NegativeBinomial { theta },
-            GlmmFamily::Gamma => LogLikKind::Gamma { dispersion },
-            GlmmFamily::Tweedie { power } => LogLikKind::Tweedie { power, dispersion },
-        }
-    }
 }
 
 /// Options for a mixed-effects fit.
@@ -112,6 +74,10 @@ pub struct GlmmOptions {
     /// 1-based index into `x` of an offset column, added to the linear predictor
     /// with coefficient 1 and removed from the design.
     pub offset_column: Option<usize>,
+    /// 0-based indices into `x` of feature columns that additionally carry a
+    /// random slope (alongside the random intercept), with an unstructured
+    /// covariance shared across groups. Empty = random intercept only.
+    pub random_slopes: Vec<usize>,
 }
 
 impl Default for GlmmOptions {
@@ -125,21 +91,34 @@ impl Default for GlmmOptions {
             confidence_level: 0.95,
             reml: true,
             offset_column: None,
+            random_slopes: Vec::new(),
         }
     }
 }
 
 /// One group's random effect.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct RandomEffect {
     /// Dense group id, matching the order groups were first seen.
     pub group: i32,
-    /// Conditional mode of the random intercept (the BLUP).
+    /// Conditional mode of the random intercept (the BLUP) — `effects[0]`.
     pub value: f64,
-    /// Conditional standard deviation.
+    /// Conditional standard deviation (NaN: not exposed by the upstream solver).
     pub se: f64,
+    /// Full random-effect vector for this group: `[intercept, slope_1, …]` in the
+    /// order the slopes were requested. Length `q`.
+    pub effects: Vec<f64>,
     /// Number of observations in the group.
     pub n: usize,
+}
+
+/// One grouping factor's random-intercept variance (crossed / nested fits).
+#[derive(Debug, Clone, Copy)]
+pub struct FactorVariance {
+    /// Number of levels of this grouping factor.
+    pub n_levels: usize,
+    /// Random-intercept variance σ²_f for this factor.
+    pub var: f64,
 }
 
 /// Result of a mixed-effects fit.
@@ -160,6 +139,9 @@ pub struct GlmmResult {
     pub var_residual: f64,
     /// Intraclass correlation `var_group / (var_group + var_residual)`.
     pub icc: f64,
+    /// Random-effects covariance matrix Σ (`q × q`, row-major). `q = 1 + #slopes`;
+    /// `random_cov[0][0] == var_group`.
+    pub random_cov: Vec<Vec<f64>>,
     pub log_likelihood: f64,
     pub aic: f64,
     pub bic: f64,
@@ -170,12 +152,21 @@ pub struct GlmmResult {
     pub iterations: u32,
     pub converged: bool,
     pub ranef: Vec<RandomEffect>,
+    /// Per-factor variance components for crossed/nested fits. Empty for the
+    /// single-factor path (whose variance is `var_group` / `random_cov`).
+    pub factors: Vec<FactorVariance>,
 }
 
-/// Fit a mixed-effects GLM with a random intercept.
+/// Fit a mixed-effects GLM with a random intercept over one grouping factor.
 ///
-/// `group_ids` must be dense group indices in `0..n_groups`; the caller (the C++
-/// aggregate) dictionary-encodes whatever key type SQL supplied.
+/// The solver itself lives upstream in [`anofox_regression::solvers::GlmmRegressor`];
+/// this function is the thin marshalling layer that filters rows, hands dense
+/// matrices to the solver, and reshapes the fit into a [`GlmmResult`].
+///
+/// `group_ids` are the caller's dense group indices; the C++ aggregate
+/// dictionary-encodes whatever key type SQL supplied. Non-finite rows and rows
+/// with a negative group id are dropped, and the surviving groups are re-compacted
+/// so the returned [`RandomEffect::group`] ids still index the caller's labels.
 pub fn fit_glmm(
     y: &[f64],
     x: &[Vec<f64>],
@@ -200,41 +191,56 @@ pub fn fit_glmm(
         }
     }
 
-    // Split off the offset column, if any.
-    let offset_idx = match options.offset_column {
-        Some(one_based) => {
-            if one_based == 0 || one_based > x.len() {
-                return Err(StatsError::InvalidValue {
-                    field: "offset",
-                    message: format!(
-                        "offset must be a 1-based index into x (1..={}), got {one_based}",
-                        x.len()
-                    ),
-                });
-            }
-            Some(one_based - 1)
+    // Offset and the NegBinomial/Gamma/Tweedie families are not yet in the upstream
+    // mixed-effects solver (tracked upstream: anofox-regression#29). Reject them
+    // explicitly rather than silently ignoring the request.
+    if options.offset_column.is_some() {
+        return Err(StatsError::InvalidValue {
+            field: "offset",
+            message: "offset is not yet supported for mixed-effects models \
+                      (tracked upstream: anofox-regression#29)"
+                .to_string(),
+        });
+    }
+    let builder = match options.family {
+        GlmmFamily::Gaussian => GlmmRegressor::gaussian(),
+        GlmmFamily::Poisson => GlmmRegressor::poisson(),
+        GlmmFamily::Binomial => GlmmRegressor::binomial(),
+        _ => {
+            return Err(StatsError::InvalidValue {
+                field: "family",
+                message: "mixed-effects models currently support gaussian, poisson and binomial \
+                          only (NegBinomial/Gamma/Tweedie tracked upstream: anofox-regression#29)"
+                    .to_string(),
+            })
         }
-        None => None,
     };
-    let feature_cols: Vec<usize> = (0..x.len()).filter(|i| Some(*i) != offset_idx).collect();
 
-    // Keep rows that are finite throughout and carry a valid group.
+    // Keep rows finite throughout and carrying a valid group.
     let rows: Vec<usize> = (0..y.len())
         .filter(|&i| y[i].is_finite() && group_ids[i] >= 0 && x.iter().all(|c| c[i].is_finite()))
         .collect();
     if rows.is_empty() {
         return Err(StatsError::NoValidData);
     }
-
     let n = rows.len();
-    let n_features = feature_cols.len();
+    let n_features = x.len();
     let n_fixed = n_features + usize::from(options.fit_intercept);
 
-    let n_groups = rows
-        .iter()
-        .map(|&i| group_ids[i] as usize + 1)
-        .max()
-        .unwrap_or(0);
+    // Re-compact group ids to a dense 0..k over the surviving rows, keeping the map
+    // back to the caller's id for labelling the random effects.
+    let mut compact: std::collections::HashMap<i32, usize> = std::collections::HashMap::new();
+    let mut orig: Vec<i32> = Vec::new();
+    let mut groups: Vec<usize> = Vec::with_capacity(n);
+    for &i in &rows {
+        let g = group_ids[i];
+        let id = *compact.entry(g).or_insert_with(|| {
+            orig.push(g);
+            orig.len() - 1
+        });
+        groups.push(id);
+    }
+    let n_groups = orig.len();
     if n_groups < 2 {
         return Err(StatsError::InvalidValue {
             field: "group",
@@ -249,20 +255,6 @@ pub fn fit_glmm(
             cols: n_fixed,
         });
     }
-
-    let yv: Vec<f64> = rows.iter().map(|&i| y[i]).collect();
-    let groups: Vec<usize> = rows.iter().map(|&i| group_ids[i] as usize).collect();
-    let offset: Option<Vec<f64>> = offset_idx.map(|oi| rows.iter().map(|&i| x[oi][i]).collect());
-
-    let int_off = usize::from(options.fit_intercept);
-    let xd = Mat::from_fn(n, n_fixed, |r, c| {
-        if options.fit_intercept && c == 0 {
-            1.0
-        } else {
-            x[feature_cols[c - int_off]][rows[r]]
-        }
-    });
-
     let mut group_sizes = vec![0usize; n_groups];
     for &g in &groups {
         group_sizes[g] += 1;
@@ -276,89 +268,108 @@ pub fn fit_glmm(
         });
     }
 
-    // Outer loop: profile over `theta = sigma_b / sigma_e`, the *ratio* of the
-    // two scales, not sigma_b itself.
-    //
-    // This matters. Henderson's mixed-model equations penalise the random block
-    // by sigma_e^2 / sigma_b^2, so the penalty is scale-free; parameterising by
-    // sigma_b alone makes the objective depend on the units of y, and doubling y
-    // then fails to quadruple the fitted variance component. lme4 profiles over
-    // the same ratio for exactly this reason. sigma_e^2 is recovered afterwards
-    // from the fit, and sigma_b^2 = theta^2 * sigma_e^2.
-    //
-    // Because theta is dimensionless, a fixed bracket works for any response.
-    let lo = 1e-4_f64.ln();
-    let hi = 1e3_f64.ln();
+    // Dense design (no intercept column; the builder adds one) and response.
+    let xm = Mat::from_fn(n, n_features, |r, c| x[c][rows[r]]);
+    let yv = Col::from_fn(n, |r| y[rows[r]]);
 
-    let objective = |log_theta: f64| -> f64 {
-        match inner_fit(
-            options,
-            &xd,
-            &yv,
-            &groups,
-            n_groups,
-            &group_sizes,
-            offset.as_deref(),
-            log_theta.exp(),
-        ) {
-            Ok(f) => f.marginal_loglik,
-            Err(_) => f64::NEG_INFINITY,
+    for &c in &options.random_slopes {
+        if c >= n_features {
+            return Err(StatsError::InvalidValue {
+                field: "random",
+                message: format!(
+                    "random-slope column {} is out of range for {} feature(s)",
+                    c + 1,
+                    n_features
+                ),
+            });
         }
+    }
+
+    let reg = builder
+        .with_intercept(options.fit_intercept)
+        .random_slopes(options.random_slopes.clone())
+        .max_iterations(options.max_iterations as usize)
+        .tolerance(options.tolerance)
+        .reml(options.reml)
+        .build();
+
+    let fit = reg
+        .fit(&xm, &yv, &groups)
+        .map_err(|e| StatsError::RegressError(format!("{e:?}")))?;
+
+    // Fixed effects: element 0 is the intercept when one is fitted.
+    let (coefficients, intercept) = if options.fit_intercept {
+        (fit.slopes().to_vec(), fit.intercept())
+    } else {
+        (fit.fixed_effects().to_vec(), None)
     };
 
-    let (best_log_theta, iterations) = brent_maximize(objective, lo, hi, options.tolerance, 200);
-    let theta = best_log_theta.exp();
-
-    let fit = inner_fit(
-        options,
-        &xd,
-        &yv,
-        &groups,
-        n_groups,
-        &group_sizes,
-        offset.as_deref(),
-        theta,
-    )?;
-
-    // Fixed-effect inference from the top-left block of the joint covariance.
+    // Inference derived from the reported fixed-effect standard errors.
     let (std_errors, z_values, p_values, ci_lower, ci_upper, intercept_std_error) =
         if options.compute_inference {
-            let inf = crate::models::glm_engine::laplace::inference(
-                &fit.beta,
-                &fit.fixed_information,
-                None,
-                fit.dispersion,
-                options.confidence_level,
-                crate::types::VcovType::Laplace,
-                &vec![false; n_fixed],
-            )?;
+            let se = fit.std_errors();
+            let normal = Normal::new(0.0, 1.0).ok();
+            let z_crit = normal
+                .as_ref()
+                .map(|nrm| nrm.inverse_cdf(0.5 + options.confidence_level / 2.0))
+                .unwrap_or(1.959_963_984_540_054);
+            let int_off = usize::from(options.fit_intercept);
+            let mut se_v = Vec::with_capacity(coefficients.len());
+            let mut z_v = Vec::with_capacity(coefficients.len());
+            let mut p_v = Vec::with_capacity(coefficients.len());
+            let mut lo_v = Vec::with_capacity(coefficients.len());
+            let mut hi_v = Vec::with_capacity(coefficients.len());
+            for (k, &b) in coefficients.iter().enumerate() {
+                let s = se.get(int_off + k).copied().unwrap_or(f64::NAN);
+                let z = if s > 0.0 { b / s } else { f64::NAN };
+                let p = match &normal {
+                    Some(nrm) if z.is_finite() => 2.0 * (1.0 - nrm.cdf(z.abs())),
+                    _ => f64::NAN,
+                };
+                se_v.push(s);
+                z_v.push(z);
+                p_v.push(p);
+                lo_v.push(b - z_crit * s);
+                hi_v.push(b + z_crit * s);
+            }
+            let icpt_se = if options.fit_intercept {
+                Some(se.first().copied().unwrap_or(f64::NAN))
+            } else {
+                None
+            };
             (
-                Some(inf.std_errors[int_off..].to_vec()),
-                Some(inf.z_values[int_off..].to_vec()),
-                Some(inf.p_values[int_off..].to_vec()),
-                Some(inf.ci_lower[int_off..].to_vec()),
-                Some(inf.ci_upper[int_off..].to_vec()),
-                if options.fit_intercept {
-                    Some(inf.std_errors[0])
-                } else {
-                    None
-                },
+                Some(se_v),
+                Some(z_v),
+                Some(p_v),
+                Some(lo_v),
+                Some(hi_v),
+                icpt_se,
             )
         } else {
             (None, None, None, None, None, None)
         };
 
+    // Per-group random-effect vectors `[intercept, slope_1, …]`. Upstream does not
+    // expose the conditional SE of the BLUPs (tracked upstream:
+    // anofox-regression#29), so `se` is NaN.
+    let re_matrix = fit.random_effects_matrix();
     let ranef: Vec<RandomEffect> = (0..n_groups)
-        .map(|g| RandomEffect {
-            group: g as i32,
-            value: fit.b[g],
-            se: fit.b_se[g],
-            n: group_sizes[g],
+        .map(|g| {
+            let effects = re_matrix.get(g).cloned().unwrap_or_default();
+            RandomEffect {
+                group: orig[g],
+                value: effects.first().copied().unwrap_or(f64::NAN),
+                se: f64::NAN,
+                effects,
+                n: group_sizes[g],
+            }
         })
         .collect();
 
-    let var_residual = fit.dispersion;
-    let var_group = theta * theta * var_residual;
+    let random_cov: Vec<Vec<f64>> = fit.random_cov().to_vec();
+
+    let var_group = fit.var_random();
+    let var_residual = fit.sigma() * fit.sigma();
     let icc = if var_group + var_residual > 0.0 {
         var_group / (var_group + var_residual)
     } else {
@@ -373,12 +384,7 @@ pub fn fit_glmm(
             options.family,
             GlmmFamily::Poisson | GlmmFamily::Binomial
         ));
-
-    let (coefficients, intercept) = if options.fit_intercept {
-        (fit.beta[1..].to_vec(), Some(fit.beta[0]))
-    } else {
-        (fit.beta.clone(), None)
-    };
+    let ll = fit.log_likelihood();
 
     Ok(GlmmResult {
         coefficients,
@@ -393,343 +399,249 @@ pub fn fit_glmm(
         var_group,
         var_residual,
         icc,
-        log_likelihood: fit.marginal_loglik,
-        aic: 2.0 * k as f64 - 2.0 * fit.marginal_loglik,
-        bic: k as f64 * (n as f64).ln() - 2.0 * fit.marginal_loglik,
-        deviance: fit.deviance,
+        random_cov,
+        log_likelihood: ll,
+        aic: 2.0 * k as f64 - 2.0 * ll,
+        bic: k as f64 * (n as f64).ln() - 2.0 * ll,
+        deviance: fit.deviance(),
         n_observations: n,
         n_groups,
         n_features,
-        iterations,
-        converged: true,
+        iterations: fit.iterations() as u32,
+        converged: fit.converged(),
         ranef,
+        factors: Vec::new(),
     })
 }
 
-/// The inner fit at a fixed `sigma_b`.
-struct InnerFit {
-    beta: Vec<f64>,
-    b: Vec<f64>,
-    b_se: Vec<f64>,
-    /// Covariance-ready information matrix for the fixed effects, after
-    /// eliminating the random effects.
-    fixed_information: Mat<f64>,
-    dispersion: f64,
-    deviance: f64,
-    /// Laplace-approximated log marginal likelihood at this `sigma_b`.
-    marginal_loglik: f64,
-}
-
-/// Penalized IRLS over `[X | Z]` with `Z` left implicit.
-///
-/// The mixed-model equations at fixed weights `W` are
-///
-/// ```text
-///   [ X'WX      X'WZ         ] [beta]   [X'Wz]
-///   [ Z'WX      Z'WZ + I/s^2 ] [ b  ] = [Z'Wz]
-/// ```
-///
-/// For a random intercept `Z` is a group indicator, so `Z'WZ` is diagonal with
-/// entry `sum_{i in g} w_i`, and `X'WZ` has one column per group. That lets the
-/// `b` block be eliminated by a rank-one-per-group update rather than by forming
-/// or factorising anything of size `n_groups`.
-#[allow(clippy::too_many_arguments)]
-fn inner_fit(
-    options: &GlmmOptions,
-    xd: &Mat<f64>,
+/// Fit a mixed-effects GLM with several crossed / nested random-**intercept**
+/// factors. `group_factors[f]` holds the caller's dense ids for factor `f`, one
+/// per observation. A single factor is exactly [`fit_glmm`]. Random slopes
+/// combined with multiple factors are not yet supported upstream
+/// (tracked: anofox-regression#29).
+pub fn fit_glmm_crossed(
     y: &[f64],
-    groups: &[usize],
-    n_groups: usize,
-    group_sizes: &[usize],
-    offset: Option<&[f64]>,
-    theta: f64,
-) -> StatsResult<InnerFit> {
-    let n = xd.nrows();
-    let p = xd.ncols();
-    // The penalty on the random block is sigma_e^2 / sigma_b^2 = 1 / theta^2.
-    // Working weights already carry the variance function, so this is the ratio
-    // in every family, with sigma_e^2 == 1 where the dispersion is fixed.
-    let lambda = 1.0 / (theta * theta);
-
-    let family = options.family.upstream();
-    let gaussian = options.family.is_gaussian();
-
-    // Working response and weights. Gaussian needs no iteration: z = y, w = 1.
-    let mut mu: Vec<f64> = match &family {
-        Some(f) => f.initialize_mu(y),
-        None => y.to_vec(),
-    };
-    let mut eta: Vec<f64> = match &family {
-        Some(f) => mu
-            .iter()
-            .enumerate()
-            .map(|(i, &m)| {
-                let base = f.link(m);
-                match offset {
-                    Some(o) => base - o[i],
-                    None => base,
-                }
-            })
-            .collect(),
-        None => mu.clone(),
-    };
-
-    let mut beta = vec![0.0; p];
-    let mut b = vec![0.0; n_groups];
-    let mut w = vec![1.0; n];
-    let mut z = y.to_vec();
-    let mut fixed_information = Mat::zeros(p, p);
-    let mut zwz = vec![0.0; n_groups];
-
-    let iters = if gaussian { 1 } else { options.max_iterations };
-
-    for _ in 0..iters {
-        if let Some(f) = &family {
-            for i in 0..n {
-                w[i] = f.irls_weight(mu[i]);
-                let eta_no_offset = match offset {
-                    Some(o) => eta[i] - o[i],
-                    None => eta[i],
-                };
-                z[i] = eta_no_offset + (y[i] - mu[i]) * f.link_derivative(mu[i]);
-            }
-        }
-
-        // Accumulate the blocks. Z is never built.
-        let mut xwx: Mat<f64> = Mat::zeros(p, p);
-        let mut xwz_t: Vec<Vec<f64>> = vec![vec![0.0; p]; n_groups]; // X'WZ, one column per group
-        let mut xwy: Col<f64> = Col::zeros(p);
-        let mut zwy = vec![0.0; n_groups];
-        zwz.iter_mut().for_each(|v| *v = 0.0);
-
-        for i in 0..n {
-            let wi = w[i];
-            if wi == 0.0 {
-                continue;
-            }
-            let g = groups[i];
-            zwz[g] += wi;
-            zwy[g] += wi * z[i];
-            for j in 0..p {
-                let xij = xd[(i, j)];
-                xwy[j] += wi * xij * z[i];
-                xwz_t[g][j] += wi * xij;
-                for k in j..p {
-                    xwx[(j, k)] += wi * xij * xd[(i, k)];
-                }
-            }
-        }
-        for j in 0..p {
-            for k in (j + 1)..p {
-                xwx[(k, j)] = xwx[(j, k)];
-            }
-        }
-
-        // Eliminate b: the Schur complement of the (diagonal) random block.
-        //   A = X'WX - sum_g (X'WZ)_g (X'WZ)_g' / d_g
-        //   c = X'Wz - sum_g (X'WZ)_g * (Z'Wz)_g / d_g          with d_g = zwz_g + lambda
-        let mut a = xwx.clone();
-        let mut c = xwy.clone();
-        for g in 0..n_groups {
-            let d = zwz[g] + lambda;
-            if d <= 0.0 {
-                continue;
-            }
-            let col = &xwz_t[g];
-            let s = zwy[g] / d;
-            for j in 0..p {
-                c[j] -= col[j] * s;
-                for k in 0..p {
-                    a[(j, k)] -= col[j] * col[k] / d;
-                }
-            }
-        }
-
-        let beta_col = crate::models::glm_engine::normal_eq::solve_qr(&a, &c, 1e-12)?;
-        for j in 0..p {
-            beta[j] = beta_col[j];
-        }
-
-        // Back-substitute the random effects, one scalar per group.
-        for g in 0..n_groups {
-            let d = zwz[g] + lambda;
-            if d <= 0.0 {
-                b[g] = 0.0;
-                continue;
-            }
-            let mut dot = 0.0;
-            for j in 0..p {
-                dot += xwz_t[g][j] * beta[j];
-            }
-            b[g] = (zwy[g] - dot) / d;
-        }
-
-        fixed_information = a.clone();
-
-        // Update eta and mu.
-        if let Some(f) = &family {
-            for i in 0..n {
-                let mut e = b[groups[i]];
-                for j in 0..p {
-                    e += xd[(i, j)] * beta[j];
-                }
-                if let Some(o) = offset {
-                    e += o[i];
-                }
-                eta[i] = e;
-                let m = f.link_inverse(e);
-                mu[i] = if f.valid_mu(m) { m } else { f.clamp_mu(m) };
-            }
-        } else {
-            for i in 0..n {
-                let mut e = b[groups[i]];
-                for j in 0..p {
-                    e += xd[(i, j)] * beta[j];
-                }
-                if let Some(o) = offset {
-                    e += o[i];
-                }
-                eta[i] = e;
-                mu[i] = e;
-            }
-        }
+    x: &[Vec<f64>],
+    group_factors: &[&[i32]],
+    options: &GlmmOptions,
+) -> StatsResult<GlmmResult> {
+    if group_factors.is_empty() {
+        return Err(StatsError::InvalidValue {
+            field: "group",
+            message: "at least one grouping factor is required".to_string(),
+        });
+    }
+    if group_factors.len() == 1 {
+        return fit_glmm(y, x, group_factors[0], options);
     }
 
-    // Residual variance / dispersion.
-    let df_resid = (n.saturating_sub(p) as f64).max(1.0);
-    let dispersion = match options.family {
-        GlmmFamily::Poisson | GlmmFamily::Binomial => 1.0,
-        GlmmFamily::Gaussian => {
-            let rss: f64 = (0..n).map(|i| (y[i] - mu[i]).powi(2)).sum();
-            let denom = if options.reml {
-                (n as f64 - p as f64).max(1.0)
-            } else {
-                n as f64
-            };
-            rss / denom
+    if y.is_empty() {
+        return Err(StatsError::EmptyInput { field: "y" });
+    }
+    for g in group_factors {
+        if g.len() != y.len() {
+            return Err(StatsError::DimensionMismatch {
+                y_len: y.len(),
+                x_rows: g.len(),
+            });
         }
+    }
+    for col in x.iter() {
+        if col.len() != y.len() {
+            return Err(StatsError::DimensionMismatch {
+                y_len: y.len(),
+                x_rows: col.len(),
+            });
+        }
+    }
+    if options.offset_column.is_some() {
+        return Err(StatsError::InvalidValue {
+            field: "offset",
+            message: "offset is not yet supported for mixed-effects models \
+                      (tracked upstream: anofox-regression#29)"
+                .to_string(),
+        });
+    }
+    if !options.random_slopes.is_empty() {
+        return Err(StatsError::InvalidValue {
+            field: "random",
+            message: "random slopes combined with multiple grouping factors are not yet \
+                      supported (tracked upstream: anofox-regression#29)"
+                .to_string(),
+        });
+    }
+    let builder = match options.family {
+        GlmmFamily::Gaussian => GlmmRegressor::gaussian(),
+        GlmmFamily::Poisson => GlmmRegressor::poisson(),
+        GlmmFamily::Binomial => GlmmRegressor::binomial(),
         _ => {
-            let f = family.as_ref().expect("non-gaussian family");
-            let chi2: f64 = (0..n)
-                .map(|i| {
-                    let v = f.variance(mu[i]);
-                    if v > 0.0 {
-                        (y[i] - mu[i]).powi(2) / v
-                    } else {
-                        0.0
-                    }
-                })
-                .sum();
-            chi2 / df_resid
+            return Err(StatsError::InvalidValue {
+                field: "family",
+                message: "mixed-effects models currently support gaussian, poisson and binomial \
+                          only (tracked upstream: anofox-regression#29)"
+                    .to_string(),
+            })
         }
     };
 
-    // Conditional standard deviations of the random effects. Ignoring the (small)
-    // covariance with the fixed effects, the conditional precision of b_g is
-    // d_g = sum_g w_i + lambda, scaled by the dispersion.
-    let b_se: Vec<f64> = (0..n_groups)
-        .map(|g| {
-            let d = zwz[g] + lambda;
-            if d > 0.0 {
-                (dispersion / d).sqrt()
-            } else {
-                f64::NAN
-            }
+    // Rows finite throughout and with a valid level in every factor.
+    let rows: Vec<usize> = (0..y.len())
+        .filter(|&i| {
+            y[i].is_finite()
+                && x.iter().all(|c| c[i].is_finite())
+                && group_factors.iter().all(|g| g[i] >= 0)
         })
         .collect();
-
-    let deviance = match &family {
-        Some(f) => f.deviance(y, &mu),
-        None => (0..n).map(|i| (y[i] - mu[i]).powi(2)).sum(),
-    };
-
-    // Laplace approximation to the log marginal likelihood:
-    //   log L ~ log f(y | b_hat) + log N(b_hat; 0, sigma_b^2) - 0.5 log|H/(2 pi)|
-    // with H the joint posterior precision of b. For a random intercept H is
-    // diagonal, so the determinant is a plain sum of logs.
-    let conditional_ll = match &family {
-        Some(_) => {
-            let kind = options.family.loglik_kind(dispersion);
-            loglik::log_likelihood(kind, y, &mu)
-        }
-        None => {
-            let s2 = dispersion.max(1e-300);
-            -0.5 * (n as f64) * (2.0 * std::f64::consts::PI * s2).ln() - deviance / (2.0 * s2)
-        }
-    };
-
-    // b ~ N(0, sigma_b^2) with sigma_b = theta * sigma_e.
-    let phi = dispersion.max(1e-300);
-    let sigma_b = theta * phi.sqrt();
-    let prior_ll: f64 = -0.5 * (n_groups as f64) * (2.0 * std::f64::consts::PI).ln()
-        - (n_groups as f64) * sigma_b.ln()
-        - 0.5 * b.iter().map(|v| v * v).sum::<f64>() / (sigma_b * sigma_b);
-
-    // Joint posterior precision of b_g is (Z'WZ)_g / phi + 1 / sigma_b^2, which is
-    // (zwz_g + lambda) / phi. Diagonal, so the determinant is a sum of logs.
-    let mut log_det = 0.0;
-    for g in 0..n_groups {
-        let d = (zwz[g] + lambda) / phi;
-        if d > 0.0 {
-            log_det += d.ln();
-        }
+    if rows.is_empty() {
+        return Err(StatsError::NoValidData);
+    }
+    let n = rows.len();
+    let n_features = x.len();
+    let n_fixed = n_features + usize::from(options.fit_intercept);
+    if n <= n_fixed + 1 {
+        return Err(StatsError::InsufficientData {
+            rows: n,
+            cols: n_fixed,
+        });
     }
 
-    let marginal_loglik = conditional_ll + prior_ll - 0.5 * log_det;
-
-    Ok(InnerFit {
-        beta,
-        b,
-        b_se,
-        fixed_information,
-        dispersion,
-        deviance,
-        marginal_loglik,
-    })
-}
-
-/// Golden-section / Brent-style maximization of a unimodal scalar function on
-/// `[lo, hi]`. Returns the maximizer and the number of iterations used.
-///
-/// Deliberately derivative-free: the Laplace objective is only piecewise smooth
-/// once the inner IRLS stopping rule is taken into account, and the search space
-/// is one-dimensional, so robustness beats speed here.
-fn brent_maximize<F: Fn(f64) -> f64>(
-    f: F,
-    mut lo: f64,
-    mut hi: f64,
-    tolerance: f64,
-    max_iter: u32,
-) -> (f64, u32) {
-    const INV_PHI: f64 = 0.618_033_988_749_894_9;
-
-    let mut c = hi - INV_PHI * (hi - lo);
-    let mut d = lo + INV_PHI * (hi - lo);
-    let mut fc = f(c);
-    let mut fd = f(d);
-    let mut iterations = 0u32;
-
-    for i in 0..max_iter {
-        iterations = i + 1;
-        if (hi - lo).abs() < tolerance.max(1e-10) {
-            break;
+    // Compact each factor independently over the surviving rows.
+    let mut factor_ids: Vec<Vec<usize>> = Vec::with_capacity(group_factors.len());
+    for g in group_factors {
+        let mut compact: std::collections::HashMap<i32, usize> = std::collections::HashMap::new();
+        let mut ids = Vec::with_capacity(n);
+        let mut next = 0usize;
+        for &i in &rows {
+            let id = *compact.entry(g[i]).or_insert_with(|| {
+                let v = next;
+                next += 1;
+                v
+            });
+            ids.push(id);
         }
-        if fc > fd {
-            hi = d;
-            d = c;
-            fd = fc;
-            c = hi - INV_PHI * (hi - lo);
-            fc = f(c);
+        if next < 2 {
+            return Err(StatsError::InvalidValue {
+                field: "group",
+                message: "each grouping factor needs at least two levels".to_string(),
+            });
+        }
+        factor_ids.push(ids);
+    }
+
+    let xm = Mat::from_fn(n, n_features, |r, c| x[c][rows[r]]);
+    let yv = Col::from_fn(n, |r| y[rows[r]]);
+
+    let reg = builder
+        .with_intercept(options.fit_intercept)
+        .max_iterations(options.max_iterations as usize)
+        .tolerance(options.tolerance)
+        .reml(options.reml)
+        .build();
+
+    let group_refs: Vec<&[usize]> = factor_ids.iter().map(|v| v.as_slice()).collect();
+    let fit = reg
+        .fit_crossed(&xm, &yv, &group_refs)
+        .map_err(|e| StatsError::RegressError(format!("{e:?}")))?;
+
+    let (coefficients, intercept) = if options.fit_intercept {
+        (fit.slopes().to_vec(), fit.intercept())
+    } else {
+        (fit.fixed_effects().to_vec(), None)
+    };
+
+    let (std_errors, z_values, p_values, ci_lower, ci_upper, intercept_std_error) =
+        if options.compute_inference {
+            let se = fit.std_errors();
+            let normal = Normal::new(0.0, 1.0).ok();
+            let z_crit = normal
+                .as_ref()
+                .map(|nrm| nrm.inverse_cdf(0.5 + options.confidence_level / 2.0))
+                .unwrap_or(1.959_963_984_540_054);
+            let int_off = usize::from(options.fit_intercept);
+            let (mut se_v, mut z_v, mut p_v, mut lo_v, mut hi_v) =
+                (Vec::new(), Vec::new(), Vec::new(), Vec::new(), Vec::new());
+            for (k, &b) in coefficients.iter().enumerate() {
+                let s = se.get(int_off + k).copied().unwrap_or(f64::NAN);
+                let z = if s > 0.0 { b / s } else { f64::NAN };
+                let p = match &normal {
+                    Some(nrm) if z.is_finite() => 2.0 * (1.0 - nrm.cdf(z.abs())),
+                    _ => f64::NAN,
+                };
+                se_v.push(s);
+                z_v.push(z);
+                p_v.push(p);
+                lo_v.push(b - z_crit * s);
+                hi_v.push(b + z_crit * s);
+            }
+            let icpt_se = if options.fit_intercept {
+                Some(se.first().copied().unwrap_or(f64::NAN))
+            } else {
+                None
+            };
+            (
+                Some(se_v),
+                Some(z_v),
+                Some(p_v),
+                Some(lo_v),
+                Some(hi_v),
+                icpt_se,
+            )
         } else {
-            lo = c;
-            c = d;
-            fc = fd;
-            d = lo + INV_PHI * (hi - lo);
-            fd = f(d);
-        }
-    }
+            (None, None, None, None, None, None)
+        };
 
-    ((lo + hi) / 2.0, iterations)
+    let factors: Vec<FactorVariance> = fit
+        .factors()
+        .iter()
+        .map(|f| FactorVariance {
+            n_levels: f.n_levels,
+            var: f.sd * f.sd,
+        })
+        .collect();
+    let var_group = factors.first().map(|f| f.var).unwrap_or(f64::NAN);
+    let var_residual = fit.sigma() * fit.sigma();
+    let total_random: f64 = factors.iter().map(|f| f.var).sum();
+    let icc = if total_random + var_residual > 0.0 {
+        total_random / (total_random + var_residual)
+    } else {
+        0.0
+    };
+
+    // k: fixed effects + one variance per factor + residual variance (Gaussian).
+    let k = n_fixed
+        + factors.len()
+        + usize::from(!matches!(
+            options.family,
+            GlmmFamily::Poisson | GlmmFamily::Binomial
+        ));
+    let ll = fit.log_likelihood();
+
+    Ok(GlmmResult {
+        coefficients,
+        intercept,
+        std_errors,
+        z_values,
+        p_values,
+        ci_lower,
+        ci_upper,
+        intercept_std_error,
+        confidence_level: options.confidence_level,
+        var_group,
+        var_residual,
+        icc,
+        random_cov: Vec::new(),
+        log_likelihood: ll,
+        aic: 2.0 * k as f64 - 2.0 * ll,
+        bic: k as f64 * (n as f64).ln() - 2.0 * ll,
+        deviance: fit.deviance(),
+        n_observations: n,
+        n_groups: fit.n_groups(),
+        n_features,
+        iterations: fit.iterations() as u32,
+        converged: fit.converged(),
+        ranef: Vec::new(),
+        factors,
+    })
 }
 
 #[cfg(test)]
@@ -898,9 +810,98 @@ mod tests {
         assert!(fit.ci_lower.as_ref().unwrap()[0] < fit.coefficients[0]);
         assert!(fit.ci_upper.as_ref().unwrap()[0] > fit.coefficients[0]);
         assert!(fit.intercept_std_error.unwrap() > 0.0);
+        // BLUPs are populated; their conditional SE is not yet exposed by the
+        // upstream solver (tracked: anofox-regression#29), so `se` is NaN for now.
         for r in &fit.ranef {
-            assert!(r.se.is_finite() && r.se > 0.0, "ranef se {}", r.se);
+            assert!(r.value.is_finite(), "ranef value {}", r.value);
+            assert!(r.se.is_nan(), "ranef se currently NaN pending upstream #29");
         }
+    }
+
+    #[test]
+    fn random_slopes_report_a_full_covariance_and_per_term_blups() {
+        // y = 1 + 0.5 x + b0_g + b1_g * x + small noise, with a group-specific
+        // intercept and slope, so both random variances are identified.
+        let n_groups = 24usize;
+        let per = 12usize;
+        let (mut y, mut xcol, mut g) = (Vec::new(), Vec::new(), Vec::new());
+        for gi in 0..n_groups {
+            let b0 = (gi as f64 - n_groups as f64 / 2.0) * 0.4;
+            let b1 = (((gi * 7) % 5) as f64 - 2.0) * 0.3;
+            for k in 0..per {
+                let xv = k as f64 / 3.0 - 2.0;
+                let noise = (((gi * per + k) % 7) as f64 - 3.0) * 0.05;
+                y.push(1.0 + 0.5 * xv + b0 + b1 * xv + noise);
+                xcol.push(xv);
+                g.push(gi as i32);
+            }
+        }
+        let x = vec![xcol];
+        let opts = GlmmOptions {
+            random_slopes: vec![0],
+            ..Default::default()
+        };
+        let fit = fit_glmm(&y, &x, &g, &opts).unwrap();
+
+        // q = 2 (intercept + one slope): a 2x2 covariance and length-2 BLUPs.
+        assert_eq!(fit.random_cov.len(), 2);
+        assert_eq!(fit.random_cov[0].len(), 2);
+        assert!(fit.random_cov[0][0] > 0.0, "intercept variance positive");
+        assert!(fit.random_cov[1][1] > 0.0, "slope variance positive");
+        assert_eq!(fit.var_group, fit.random_cov[0][0]);
+        for r in &fit.ranef {
+            assert_eq!(r.effects.len(), 2, "per-group [intercept, slope]");
+        }
+
+        // An out-of-range slope column is rejected.
+        let bad = GlmmOptions {
+            random_slopes: vec![5],
+            ..Default::default()
+        };
+        assert!(fit_glmm(&y, &x, &g, &bad).is_err());
+    }
+
+    #[test]
+    fn crossed_factors_report_per_factor_variances() {
+        // Two crossed factors: region (3 levels) and store (5 levels), each with
+        // its own random intercept on top of a fixed slope.
+        let (mut y, mut xcol, mut region, mut store) =
+            (Vec::new(), Vec::new(), Vec::new(), Vec::new());
+        for i in 0..150usize {
+            let r = (i % 3) as i32;
+            let s = (i % 5) as i32;
+            let xv = (i % 7) as f64 / 3.0;
+            y.push(
+                1.0 + 0.5 * xv
+                    + (r as f64 - 1.0) * 0.8
+                    + (s as f64 - 2.0) * 0.5
+                    + (((i * 13) % 5) as f64 - 2.0) * 0.05,
+            );
+            xcol.push(xv);
+            region.push(r);
+            store.push(s);
+        }
+        let x = vec![xcol];
+        let opts = GlmmOptions::default();
+
+        let fit = fit_glmm_crossed(&y, &x, &[&region, &store], &opts).unwrap();
+        assert_eq!(fit.factors.len(), 2, "one variance component per factor");
+        assert_eq!(fit.factors[0].n_levels, 3);
+        assert_eq!(fit.factors[1].n_levels, 5);
+        assert!(fit.factors[0].var >= 0.0 && fit.factors[1].var >= 0.0);
+        assert!(fit.converged);
+
+        // A single factor delegates to the single-factor path (ranef/random_cov).
+        let single = fit_glmm_crossed(&y, &x, &[&region], &opts).unwrap();
+        assert!(single.factors.is_empty());
+        assert_eq!(single.n_groups, 3);
+
+        // Random slopes combined with multiple factors is rejected.
+        let bad = GlmmOptions {
+            random_slopes: vec![0],
+            ..Default::default()
+        };
+        assert!(fit_glmm_crossed(&y, &x, &[&region, &store], &bad).is_err());
     }
 
     #[test]

--- a/crates/anofox-stats-core/src/models/mod.rs
+++ b/crates/anofox-stats-core/src/models/mod.rs
@@ -36,7 +36,9 @@ pub use glm::{
     fit_binomial, fit_gamma, fit_logistic, fit_negbinomial, fit_poisson, fit_tweedie, GlmResult,
     LogisticResult,
 };
-pub use glmm::{fit_glmm, GlmmFamily, GlmmOptions, GlmmResult, RandomEffect};
+pub use glmm::{
+    fit_glmm, fit_glmm_crossed, FactorVariance, GlmmFamily, GlmmOptions, GlmmResult, RandomEffect,
+};
 pub use huber::{fit_huber, HuberResult};
 pub use isotonic::fit_isotonic;
 pub use lars::fit_lars;

--- a/crates/anofox-stats-ffi/src/lib.rs
+++ b/crates/anofox-stats-ffi/src/lib.rs
@@ -10,10 +10,11 @@ use anofox_stats_core::{
     diagnostics::{compute_aic, compute_bic, compute_residuals, compute_vif, jarque_bera},
     models::{
         compute_aid, compute_aid_anomalies, eb_shrink, fit_aft, fit_alm, fit_binomial, fit_bls,
-        fit_elasticnet, fit_gamma, fit_glmm, fit_huber, fit_isotonic, fit_lars, fit_lm_dynamic,
-        fit_logistic, fit_negbinomial, fit_ols, fit_pls, fit_poisson, fit_quantile, fit_ransac,
-        fit_ridge, fit_rls, fit_theilsen, fit_tweedie, fit_wls, predict, AftDistribution,
-        AftOptions, EbShrinkOptions, GlmmFamily, GlmmOptions, RlsOptions, TauMethod,
+        fit_elasticnet, fit_gamma, fit_glmm, fit_glmm_crossed, fit_huber, fit_isotonic, fit_lars,
+        fit_lm_dynamic, fit_logistic, fit_negbinomial, fit_ols, fit_pls, fit_poisson, fit_quantile,
+        fit_ransac, fit_ridge, fit_rls, fit_theilsen, fit_tweedie, fit_wls, predict,
+        AftDistribution, AftOptions, EbShrinkOptions, GlmmFamily, GlmmOptions, RlsOptions,
+        TauMethod,
     },
     AidOptions, AlmDistribution, AlmLoss, AlmOptions, BinomialLink, BinomialOptions, BlsOptions,
     ElasticNetOptions, GammaOptions, GlmPriorOptions, HcType, HuberOptions, InformationCriterion,
@@ -7688,6 +7689,8 @@ pub unsafe extern "C" fn anofox_glmm_fit(
     x_count: usize,
     group_ids: *const i32,
     n_obs: usize,
+    extra_group_ids: *const *const i32,
+    n_extra_factors: usize,
     options: GlmmOptionsFFI,
     out_result: *mut GlmmResultFFI,
     out_error: *mut AnofoxError,
@@ -7726,6 +7729,13 @@ pub unsafe extern "C" fn anofox_glmm_fit(
         },
     };
 
+    let random_slopes: Vec<usize> =
+        if options.random_slopes.is_null() || options.random_slopes_len == 0 {
+            Vec::new()
+        } else {
+            slice::from_raw_parts(options.random_slopes, options.random_slopes_len).to_vec()
+        };
+
     let opts = GlmmOptions {
         family,
         fit_intercept: options.fit_intercept,
@@ -7739,10 +7749,30 @@ pub unsafe extern "C" fn anofox_glmm_fit(
         } else {
             Some(options.offset_column)
         },
+        random_slopes,
+    };
+
+    // Additional crossed/nested grouping factors, if any.
+    let extra_factors: Vec<Vec<i32>> = if n_extra_factors == 0 || extra_group_ids.is_null() {
+        Vec::new()
+    } else {
+        slice::from_raw_parts(extra_group_ids, n_extra_factors)
+            .iter()
+            .map(|&p| slice::from_raw_parts(p, n_obs).to_vec())
+            .collect()
     };
 
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        fit_glmm(&y_vec, &x_vecs, &groups, &opts)
+        if extra_factors.is_empty() {
+            fit_glmm(&y_vec, &x_vecs, &groups, &opts)
+        } else {
+            let mut factors: Vec<&[i32]> = Vec::with_capacity(1 + extra_factors.len());
+            factors.push(&groups);
+            for e in &extra_factors {
+                factors.push(e.as_slice());
+            }
+            fit_glmm_crossed(&y_vec, &x_vecs, &factors, &opts)
+        }
     }));
 
     let outcome = match outcome {
@@ -7762,6 +7792,15 @@ pub unsafe extern "C" fn anofox_glmm_fit(
             let ranef_value: Vec<f64> = r.ranef.iter().map(|e| e.value).collect();
             let ranef_se: Vec<f64> = r.ranef.iter().map(|e| e.se).collect();
             let ranef_n: Vec<i64> = r.ranef.iter().map(|e| e.n as i64).collect();
+            let random_dim = r.random_cov.len();
+            let random_cov_flat: Vec<f64> = r.random_cov.iter().flatten().copied().collect();
+            let ranef_effects_flat: Vec<f64> = r
+                .ranef
+                .iter()
+                .flat_map(|e| e.effects.iter().copied())
+                .collect();
+            let factor_var: Vec<f64> = r.factors.iter().map(|f| f.var).collect();
+            let factor_levels: Vec<i64> = r.factors.iter().map(|f| f.n_levels as i64).collect();
 
             let inference_len = r.std_errors.as_ref().map_or(0, |v| v.len());
 
@@ -7794,6 +7833,12 @@ pub unsafe extern "C" fn anofox_glmm_fit(
                 ranef_se: alloc_f64(&ranef_se),
                 ranef_n: alloc_i64(&ranef_n),
                 ranef_len: r.ranef.len(),
+                random_cov: alloc_f64(&random_cov_flat),
+                random_dim,
+                ranef_effects: alloc_f64(&ranef_effects_flat),
+                factor_var: alloc_f64(&factor_var),
+                factor_n_levels: alloc_i64(&factor_levels),
+                factor_len: r.factors.len(),
             };
             true
         }
@@ -7824,11 +7869,18 @@ pub unsafe extern "C" fn anofox_free_glmm_result(result: *mut GlmmResultFFI) {
         &mut (*result).ci_upper,
         &mut (*result).ranef_value,
         &mut (*result).ranef_se,
+        &mut (*result).random_cov,
+        &mut (*result).ranef_effects,
+        &mut (*result).factor_var,
     ] {
         if !p.is_null() {
             libc::free(*p as *mut libc::c_void);
             *p = std::ptr::null_mut();
         }
+    }
+    if !(*result).factor_n_levels.is_null() {
+        libc::free((*result).factor_n_levels as *mut libc::c_void);
+        (*result).factor_n_levels = std::ptr::null_mut();
     }
     if !(*result).ranef_group.is_null() {
         libc::free((*result).ranef_group as *mut libc::c_void);

--- a/crates/anofox-stats-ffi/src/types.rs
+++ b/crates/anofox-stats-ffi/src/types.rs
@@ -2512,6 +2512,10 @@ pub struct GlmmOptionsFFI {
     pub power: f64,
     /// 1-based index into `x` of an offset column; 0 means none.
     pub offset_column: usize,
+    /// Pointer to `random_slopes_len` 0-based indices into `x` of columns that
+    /// additionally carry a random slope. Null/zero-length = random intercept only.
+    pub random_slopes: *const usize,
+    pub random_slopes_len: usize,
 }
 
 impl Default for GlmmOptionsFFI {
@@ -2527,6 +2531,8 @@ impl Default for GlmmOptionsFFI {
             theta: 1.0,
             power: 1.5,
             offset_column: 0,
+            random_slopes: std::ptr::null(),
+            random_slopes_len: 0,
         }
     }
 }
@@ -2564,4 +2570,16 @@ pub struct GlmmResultFFI {
     pub ranef_se: *mut f64,
     pub ranef_n: *mut i64,
     pub ranef_len: usize,
+    /// Random-effects covariance Σ, flattened row-major `random_dim × random_dim`.
+    pub random_cov: *mut f64,
+    /// `q = 1 + number of random slopes`.
+    pub random_dim: usize,
+    /// Per-group random-effect vectors `[intercept, slope_1, …]`, flattened
+    /// row-major `ranef_len × random_dim`.
+    pub ranef_effects: *mut f64,
+    /// Per-factor variance components for crossed/nested fits (length
+    /// `factor_len`). Empty for the single-factor path.
+    pub factor_var: *mut f64,
+    pub factor_n_levels: *mut i64,
+    pub factor_len: usize,
 }

--- a/docs/api/glm/glmm.md
+++ b/docs/api/glm/glmm.md
@@ -30,16 +30,21 @@ anofox_stats_glmm_fit_agg(
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| family | VARCHAR | 'gaussian' | `gaussian`, `poisson`, `binomial`, `negbinomial`, `gamma`, `tweedie` |
+| family | VARCHAR | 'gaussian' | `gaussian`, `poisson`, or `binomial` |
 | fit_intercept | BOOLEAN | true | Include a fixed intercept |
 | reml | BOOLEAN | true | REML rather than ML for the Gaussian variance components |
-| theta | DOUBLE | 1.0 | Negative Binomial dispersion |
-| power | DOUBLE | 1.5 | Tweedie variance power |
-| offset | INTEGER | — | 1-based index into `x` of an offset column (see below) |
+| random | INTEGER[] | — | 1-based indices into `x` of feature columns that also get a **random slope** (unstructured covariance with the intercept) |
+| groups | INTEGER[] | — | 1-based indices into `x` of additional **crossed** grouping-factor columns; each becomes an independent random intercept and is removed from the design |
 | max_iterations | INTEGER | 100 | Inner PIRLS iterations |
 | tolerance | DOUBLE | 1e-8 | Convergence tolerance |
 | compute_inference | BOOLEAN | false | Fixed-effect standard errors, z-tests, intervals |
 | confidence_level | DOUBLE | 0.95 | Interval level |
+
+> The solver lives upstream in `anofox-regression`; this extension is a wrapper.
+> Not yet available (tracked upstream, [anofox-regression#29](https://github.com/sipemu/anofox-regression/issues/29)):
+> NegBinomial/Gamma/Tweedie mixed-effects families, an `offset`, per-group BLUP
+> standard errors, and random slopes combined with multiple grouping factors.
+> Requesting an unsupported combination returns a clear error / `NULL`.
 
 **Returns:**
 
@@ -48,7 +53,10 @@ STRUCT(coefficients DOUBLE[], intercept DOUBLE,
        var_group DOUBLE, var_residual DOUBLE, icc DOUBLE,
        log_likelihood DOUBLE, aic DOUBLE, bic DOUBLE, deviance DOUBLE,
        n_observations BIGINT, n_groups BIGINT, n_features BIGINT,
-       iterations INTEGER, converged BOOLEAN
+       iterations INTEGER, converged BOOLEAN,
+       random_cov DOUBLE[],           -- Sigma, flattened row-major (random_dim x random_dim)
+       random_dim INTEGER,            -- q = 1 + number of random slopes
+       factors LIST(STRUCT(n_levels BIGINT, var DOUBLE))  -- per-factor variances (crossed fits)
      [, std_errors DOUBLE[], z_values DOUBLE[], p_values DOUBLE[],
         ci_lower DOUBLE[], ci_upper DOUBLE[], intercept_std_error DOUBLE],
        ranef LIST(STRUCT(group VARCHAR, intercept DOUBLE, se DOUBLE, n BIGINT)))
@@ -57,11 +65,17 @@ STRUCT(coefficients DOUBLE[], intercept DOUBLE,
 **Example:**
 
 ```sql
--- Intermittent demand across thousands of SKUs
+-- Random intercept over SKUs (Poisson counts)
 SELECT glmm_fit_agg(qty, [promo], sku, {
-    'family': 'negbinomial',
+    'family': 'poisson',
     'compute_inference': true
 }) FROM demand;
+
+-- Random intercept + random slope on promo (x-column 1); read Sigma from random_cov
+SELECT glmm_fit_agg(qty, [promo], sku, {'random': [1]}) FROM demand;
+
+-- Crossed factors: sku (positional) and region (x-column 2, named in 'groups')
+SELECT glmm_fit_agg(qty, [promo, region], sku, {'groups': [2]}) FROM demand;
 
 -- One row per SKU, with its shrunken effect
 SELECT * FROM glmm_fit_by('demand', sku, qty, [promo]);
@@ -85,26 +99,29 @@ little the group has to say.
 | `var_group` | `sigma_b^2`, the between-group variance |
 | `var_residual` | Residual variance; 1.0 for Poisson and Binomial, where the dispersion is fixed |
 | `icc` | `var_group / (var_group + var_residual)`. Near 1 means group identity explains most of the variation; near 0 means the groups are interchangeable and a pooled fit would do. |
-| `ranef` | One entry per group: the BLUP, its conditional standard error, and the group's observation count |
+| `random_cov` / `random_dim` | The random-effects covariance Σ, flattened row-major as a length-`random_dim²` list. For a plain random intercept `random_dim = 1` and `random_cov = [var_group]`; with a random slope `random_dim = 2` and Σ is `[σ²_int, cov, cov, σ²_slope]`. |
+| `factors` | For **crossed** fits, one `{n_levels, var}` per grouping factor. Empty for a single-factor fit (use `var_group` / `random_cov` instead). |
+| `ranef` | One entry per group: the intercept BLUP, its conditional SE, and the observation count. (The SE is currently `NaN` — not yet exposed by the upstream solver.) |
 
 The BLUPs are labelled with the original grouping key, whatever its type.
 
-## Offsets
-
-The issue's motivating example needs an exposure offset. Since an offset is
-per-row it cannot be a scalar option, and the overload space is already taken, so
-it is addressed by position:
+## Random slopes and crossed factors
 
 ```sql
--- x = [promo, log_exposure]; the second column is the offset
-SELECT glmm_fit_agg(qty, [promo, LN(exposure)], sku, {
-    'family': 'negbinomial',
-    'offset': 2
-}) FROM demand;
+-- Random slope on x-column 1 (unstructured covariance with the intercept).
+-- random_dim = 2 and random_cov holds the 2x2 Sigma.
+SELECT glmm_fit_agg(y, [x], grp, {'random': [1]}) FROM t;
+
+-- Crossed factors: grp is the positional factor; the second x-column is a
+-- second, independent random intercept named by its 1-based index in 'groups'.
+-- It is dictionary-encoded and removed from the design; per-factor variances
+-- come back in `factors`.
+SELECT glmm_fit_agg(y, [x, region], grp, {'groups': [2]}) FROM t;
 ```
 
-That column is removed from the design and added to the linear predictor with
-coefficient fixed at 1. Take logs yourself if the link needs it.
+Nesting `(1|a/b)` is expressed by passing the composed `a:b` key as a factor
+column. Random slopes combined with multiple grouping factors is not yet
+supported (tracked upstream, anofox-regression#29).
 
 ## Degenerate inputs
 
@@ -119,8 +136,11 @@ dropped; `n_observations` reports how many were used.
 
 ## Scope
 
-One random intercept over one grouping factor. Random slopes and crossed or
-nested grouping factors are not supported yet.
+Random intercept and random slopes over one grouping factor, or several crossed /
+nested random-intercept factors, for the gaussian, poisson and binomial families.
+Not yet available (tracked upstream, anofox-regression#29): NegBinomial/Gamma/
+Tweedie mixed-effects families, an offset, per-group BLUP standard errors, and
+random slopes combined with multiple grouping factors.
 
 If you already have per-group estimates and only want them shrunk, the cheaper
 [empirical-Bayes helper](eb_shrink.md) gets most of the way there.

--- a/src/aggregate_functions/glmm_aggregate.cpp
+++ b/src/aggregate_functions/glmm_aggregate.cpp
@@ -43,6 +43,10 @@ struct GlmmAggregateState {
 	double theta;
 	double power;
 	idx_t offset_column;
+	//! 0-based indices into x of columns that also carry a random slope.
+	vector<idx_t> random_slopes;
+	//! 0-based indices into x of additional crossed grouping-factor columns.
+	vector<idx_t> group_columns;
 
 	GlmmAggregateState()
 	    : n_features(0), initialized(false), family(ANOFOX_GLMM_GAUSSIAN), fit_intercept(true), max_iterations(100),
@@ -83,6 +87,8 @@ struct GlmmAggregateBindData : public FunctionData {
 	double theta = 1.0;
 	double power = 1.5;
 	idx_t offset_column = 0;
+	vector<idx_t> random_slopes;
+	vector<idx_t> group_columns;
 
 	unique_ptr<FunctionData> Copy() const override {
 		auto r = make_uniq<GlmmAggregateBindData>();
@@ -96,6 +102,8 @@ struct GlmmAggregateBindData : public FunctionData {
 		r->theta = theta;
 		r->power = power;
 		r->offset_column = offset_column;
+		r->random_slopes = random_slopes;
+		r->group_columns = group_columns;
 		return std::move(r);
 	}
 
@@ -104,7 +112,8 @@ struct GlmmAggregateBindData : public FunctionData {
 		return family == o.family && fit_intercept == o.fit_intercept && max_iterations == o.max_iterations &&
 		       tolerance == o.tolerance && compute_inference == o.compute_inference &&
 		       confidence_level == o.confidence_level && reml == o.reml && theta == o.theta && power == o.power &&
-		       offset_column == o.offset_column;
+		       offset_column == o.offset_column && random_slopes == o.random_slopes &&
+		       group_columns == o.group_columns;
 	}
 };
 
@@ -131,6 +140,14 @@ static LogicalType GetGlmmResultType(bool compute_inference) {
 	children.push_back(make_pair("n_features", LogicalType::BIGINT));
 	children.push_back(make_pair("iterations", LogicalType::INTEGER));
 	children.push_back(make_pair("converged", LogicalType::BOOLEAN));
+	// Random-effects covariance Sigma, flattened row-major (random_dim x random_dim).
+	children.push_back(make_pair("random_cov", LogicalType::LIST(LogicalType::DOUBLE)));
+	children.push_back(make_pair("random_dim", LogicalType::INTEGER));
+	// Per-factor variance components for crossed/nested fits (empty otherwise).
+	child_list_t<LogicalType> factor_children;
+	factor_children.push_back(make_pair("n_levels", LogicalType::BIGINT));
+	factor_children.push_back(make_pair("var", LogicalType::DOUBLE));
+	children.push_back(make_pair("factors", LogicalType::LIST(LogicalType::STRUCT(std::move(factor_children)))));
 
 	if (compute_inference) {
 		children.push_back(make_pair("std_errors", LogicalType::LIST(LogicalType::DOUBLE)));
@@ -198,6 +215,8 @@ static void GlmmAggUpdate(Vector inputs[], AggregateInputData &aggr_input_data, 
 		state.theta = bind_data.theta;
 		state.power = bind_data.power;
 		state.offset_column = bind_data.offset_column;
+		state.random_slopes = bind_data.random_slopes;
+		state.group_columns = bind_data.group_columns;
 
 		auto y_idx = y_data.sel->get_index(i);
 		auto x_idx = x_data.sel->get_index(i);
@@ -260,6 +279,8 @@ static void GlmmAggCombine(Vector &source_vector, Vector &target_vector, Aggrega
 			target.theta = source.theta;
 			target.power = source.power;
 			target.offset_column = source.offset_column;
+			target.random_slopes = source.random_slopes;
+			target.group_columns = source.group_columns;
 		}
 		if (source.n_features != target.n_features) {
 			throw InvalidInputException("Inconsistent feature count during combine");
@@ -306,10 +327,42 @@ static void GlmmAggFinalize(Vector &state_vector, AggregateInputData &, Vector &
 		}
 
 		AnofoxDataArray y_array {state.y_values.data(), nullptr, state.y_values.size()};
+
+		// Additional crossed grouping factors are dictionary-encoded here and
+		// removed from the design (like the offset column).
+		vector<bool> is_group_col(state.n_features, false);
+		for (auto gc : state.group_columns) {
+			if (gc < state.n_features) {
+				is_group_col[gc] = true;
+			}
+		}
 		vector<AnofoxDataArray> x_arrays;
-		x_arrays.reserve(state.n_features);
 		for (idx_t j = 0; j < state.n_features; j++) {
-			x_arrays.push_back(AnofoxDataArray {state.x_columns[j].data(), nullptr, state.x_columns[j].size()});
+			if (!is_group_col[j]) {
+				x_arrays.push_back(AnofoxDataArray {state.x_columns[j].data(), nullptr, state.x_columns[j].size()});
+			}
+		}
+		vector<vector<int32_t>> extra_factor_ids;
+		for (auto gc : state.group_columns) {
+			if (gc >= state.n_features) {
+				continue;
+			}
+			unordered_map<double, int32_t> levels;
+			vector<int32_t> ids;
+			ids.reserve(state.x_columns[gc].size());
+			for (double v : state.x_columns[gc]) {
+				auto it = levels.find(v);
+				int32_t id = (it == levels.end()) ? (int32_t)levels.size() : it->second;
+				if (it == levels.end()) {
+					levels.emplace(v, id);
+				}
+				ids.push_back(id);
+			}
+			extra_factor_ids.push_back(std::move(ids));
+		}
+		vector<const int32_t *> extra_ptrs;
+		for (auto &f : extra_factor_ids) {
+			extra_ptrs.push_back(f.data());
 		}
 
 		AnofoxGlmmOptions options {};
@@ -323,11 +376,14 @@ static void GlmmAggFinalize(Vector &state_vector, AggregateInputData &, Vector &
 		options.theta = state.theta;
 		options.power = state.power;
 		options.offset_column = state.offset_column;
+		options.random_slopes = state.random_slopes.empty() ? nullptr : state.random_slopes.data();
+		options.random_slopes_len = state.random_slopes.size();
 
 		AnofoxGlmmResult res {};
 		AnofoxError error;
 		bool ok = anofox_glmm_fit(y_array, x_arrays.data(), x_arrays.size(), state.group_ids.data(),
-		                          state.group_ids.size(), options, &res, &error);
+		                          state.group_ids.size(), extra_ptrs.empty() ? nullptr : extra_ptrs.data(),
+		                          extra_ptrs.size(), options, &res, &error);
 		if (!ok) {
 			FlatVector::SetNull(result, row, true);
 			state.Reset();
@@ -349,6 +405,27 @@ static void GlmmAggFinalize(Vector &state_vector, AggregateInputData &, Vector &
 		FlatVector::GetData<int64_t>(*struct_entries[c++])[row] = (int64_t)res.n_features;
 		FlatVector::GetData<int32_t>(*struct_entries[c++])[row] = (int32_t)res.iterations;
 		FlatVector::GetData<bool>(*struct_entries[c++])[row] = res.converged;
+		SetDoubleListG(*struct_entries[c++], row, res.random_cov, res.random_dim * res.random_dim);
+		FlatVector::GetData<int32_t>(*struct_entries[c++])[row] = (int32_t)res.random_dim;
+
+		// Per-factor variance components LIST(STRUCT(n_levels, var)).
+		{
+			auto &fac_vec = *struct_entries[c++];
+			auto fac_list = FlatVector::GetData<list_entry_t>(fac_vec);
+			auto fac_off = ListVector::GetListSize(fac_vec);
+			ListVector::Reserve(fac_vec, fac_off + res.factor_len);
+			auto &fac_struct = ListVector::GetEntry(fac_vec);
+			auto &fac_children = StructVector::GetEntries(fac_struct);
+			auto f_levels = FlatVector::GetData<int64_t>(*fac_children[0]);
+			auto f_var = FlatVector::GetData<double>(*fac_children[1]);
+			for (idx_t j = 0; j < res.factor_len; j++) {
+				f_levels[fac_off + j] = (int64_t)res.factor_n_levels[j];
+				f_var[fac_off + j] = res.factor_var[j];
+			}
+			ListVector::SetListSize(fac_vec, fac_off + res.factor_len);
+			fac_list[row].offset = fac_off;
+			fac_list[row].length = res.factor_len;
+		}
 
 		if (state.compute_inference) {
 			SetDoubleListG(*struct_entries[c++], row, res.std_errors, res.inference_len);
@@ -424,6 +501,17 @@ static unique_ptr<FunctionData> GlmmAggBind(ClientContext &context, AggregateFun
 		}
 		if (opts.offset_column.has_value()) {
 			result->offset_column = opts.offset_column.value();
+		}
+		if (opts.random_slopes.has_value()) {
+			// Options carry 1-based indices; the core/FFI want 0-based.
+			for (auto idx1 : opts.random_slopes.value()) {
+				result->random_slopes.push_back(idx1 - 1);
+			}
+		}
+		if (opts.group_columns.has_value()) {
+			for (auto idx1 : opts.group_columns.value()) {
+				result->group_columns.push_back(idx1 - 1);
+			}
 		}
 	}
 

--- a/src/include/anofox_stats_ffi.h
+++ b/src/include/anofox_stats_ffi.h
@@ -2453,6 +2453,10 @@ typedef struct {
 	double power;
 	/** 1-based index into x of an offset column; 0 means none. */
 	size_t offset_column;
+	/** Pointer to random_slopes_len 0-based indices into x of columns that also
+	    carry a random slope. Null/zero-length = random intercept only. */
+	const size_t *random_slopes;
+	size_t random_slopes_len;
 } AnofoxGlmmOptions;
 
 typedef struct {
@@ -2485,6 +2489,18 @@ typedef struct {
 	double *ranef_se;
 	int64_t *ranef_n;
 	size_t ranef_len;
+	/** Random-effects covariance Sigma, flattened row-major random_dim x random_dim. */
+	double *random_cov;
+	/** q = 1 + number of random slopes. */
+	size_t random_dim;
+	/** Per-group random-effect vectors [intercept, slope_1, ...], flattened
+	    row-major ranef_len x random_dim. */
+	double *ranef_effects;
+	/** Per-factor variance components for crossed/nested fits (length factor_len);
+	    empty for the single-factor path. */
+	double *factor_var;
+	int64_t *factor_n_levels;
+	size_t factor_len;
 } AnofoxGlmmResult;
 
 /**
@@ -2493,7 +2509,8 @@ typedef struct {
  * @param group_ids Dense group indices in 0..n_groups, one per observation
  */
 bool anofox_glmm_fit(AnofoxDataArray y, const AnofoxDataArray *x, size_t x_count, const int32_t *group_ids,
-                     size_t n_obs, AnofoxGlmmOptions options, AnofoxGlmmResult *out_result, AnofoxError *out_error);
+                     size_t n_obs, const int32_t *const *extra_group_ids, size_t n_extra_factors,
+                     AnofoxGlmmOptions options, AnofoxGlmmResult *out_result, AnofoxError *out_error);
 
 /** Free the arrays owned by a GLMM result. */
 void anofox_free_glmm_result(AnofoxGlmmResult *result);

--- a/src/include/map_options_parser.cpp
+++ b/src/include/map_options_parser.cpp
@@ -440,6 +440,29 @@ static std::optional<VcovTypeOpt> ExtractVcovType(const Value &val) {
 	throw InvalidInputException("Unknown vcov type '%s'. Expected 'laplace', 'sandwich' or 'naive'.", val.ToString());
 }
 
+// Extract a LIST of positive integers (1-based column indices).
+static std::optional<vector<idx_t>> ExtractIndexList(const Value &val) {
+	if (val.IsNull()) {
+		return std::nullopt;
+	}
+	if (val.type().id() != LogicalTypeId::LIST) {
+		throw InvalidInputException("'random' must be a LIST of integer column indices, got %s",
+		                            val.type().ToString());
+	}
+	vector<idx_t> out;
+	for (auto &child : ListValue::GetChildren(val)) {
+		if (child.IsNull()) {
+			throw InvalidInputException("'random' must not contain NULL");
+		}
+		auto v = child.GetValue<int64_t>();
+		if (v < 1) {
+			throw InvalidInputException("'random' indices are 1-based and must be >= 1, got %lld", (long long)v);
+		}
+		out.push_back((idx_t)v);
+	}
+	return out;
+}
+
 static std::optional<vector<string>> ExtractStringList(const Value &val) {
 	if (val.IsNull()) {
 		return std::nullopt;
@@ -752,6 +775,10 @@ RegressionMapOptions RegressionMapOptions::ParseFromValue(const Value &map_value
 			if (v.has_value()) {
 				result.offset_column = (idx_t)v.value();
 			}
+		} else if (key == "random" || key == "random_slopes") {
+			result.random_slopes = ExtractIndexList(val);
+		} else if (key == "groups" || key == "crossed") {
+			result.group_columns = ExtractIndexList(val);
 		} else if (key == "tau_squared" || key == "tau2") {
 			result.tau_squared = ExtractDouble(val);
 		} else if (key == "tau_method" || key == "shrinkage") {

--- a/src/include/map_options_parser.hpp
+++ b/src/include/map_options_parser.hpp
@@ -178,6 +178,10 @@ struct RegressionMapOptions {
 	std::optional<int> glmm_family;     // Mirrors AnofoxGlmmFamily
 	std::optional<bool> reml;           // REML vs ML variance components
 	std::optional<idx_t> offset_column; // 1-based index into x; 0/unset = none
+	//! 1-based indices into x of columns that also carry a random slope (GLMM).
+	std::optional<vector<idx_t>> random_slopes;
+	//! 1-based indices into x of additional crossed grouping-factor columns (GLMM).
+	std::optional<vector<idx_t>> group_columns;
 
 	// Empirical-Bayes shrinkage (issue #107)
 	std::optional<double> tau_squared; // Fixed between-group variance; unset = estimate

--- a/test/sql/regression/test_glmm.test
+++ b/test/sql/regression/test_glmm.test
@@ -73,9 +73,12 @@ FROM (
 ----
 true
 
-# ==== TEST 7: conditional standard errors are finite and positive ====
+# ==== TEST 7: BLUP conditional standard errors ====
+# The upstream mixed-effects solver does not yet expose the per-group BLUP
+# conditional SE (tracked: anofox-regression#29), so `se` is NaN for now while
+# the BLUP value itself is finite.
 query I
-SELECT bool_and(r.se > 0.0 AND NOT isnan(r.se))
+SELECT bool_and(isnan(r.se) AND NOT isnan(r.intercept))
 FROM (SELECT glmm_fit_agg(y, [x], sku) AS f FROM panel) t, LATERAL UNNEST(t.f.ranef) AS u(r);
 ----
 true
@@ -180,6 +183,69 @@ true
 
 statement ok
 DROP TABLE IF EXISTS panel_nulls;
+
+# ==== TEST 15: random slopes (#109) — q grows and Sigma is q x q ====
+# Random intercept only: q = 1, Sigma is 1x1.
+query II
+SELECT (glmm_fit_agg(y, [x], sku)).random_dim,
+       len((glmm_fit_agg(y, [x], sku)).random_cov)
+FROM panel;
+----
+1	1
+
+# Random intercept + a random slope on x (1-based column index): q = 2, Sigma 2x2.
+query II
+SELECT (glmm_fit_agg(y, [x], sku, {'random': [1]})).random_dim,
+       len((glmm_fit_agg(y, [x], sku, {'random': [1]})).random_cov)
+FROM panel;
+----
+2	4
+
+# Sigma is symmetric with a positive intercept variance (row-major [00,01,10,11]).
+query I
+SELECT (c[1] > 0.0) AND (c[2] = c[3])
+FROM (SELECT (glmm_fit_agg(y, [x], sku, {'random': [1]})).random_cov AS c FROM panel) t;
+----
+true
+
+# ==== TEST 16: an out-of-range random-slope column yields NULL (fit fails) ====
+query I
+SELECT (glmm_fit_agg(y, [x], sku, {'random': [5]})) IS NULL FROM panel;
+----
+true
+
+# ==== TEST 17: crossed grouping factors (#109) via the options MAP ====
+statement ok
+CREATE TABLE crossed AS
+SELECT (i % 3)::DOUBLE AS region, (i % 5)::DOUBLE AS store, ((i % 7) / 3.0) AS x,
+       1.0 + 0.5 * ((i % 7) / 3.0) + ((i % 3) - 1) * 0.8 + ((i % 5) - 2) * 0.5
+           + (((i * 13) % 5) - 2) * 0.05 AS y
+FROM range(0, 150) t(i);
+
+# region is the positional factor; store (x-column 2) is a second crossed factor,
+# which is removed from the design (so n_features drops back to 1).
+query II
+SELECT len((glmm_fit_agg(y, [x, store], region, {'groups': [2]})).factors),
+       (glmm_fit_agg(y, [x, store], region, {'groups': [2]})).n_features
+FROM crossed;
+----
+2	1
+
+# per-factor level counts and non-negative variances
+query I
+SELECT (f[1].n_levels = 3) AND (f[2].n_levels = 5) AND (f[1].var >= 0.0) AND (f[2].var >= 0.0)
+FROM (SELECT (glmm_fit_agg(y, [x, store], region, {'groups': [2]})).factors AS f FROM crossed) t;
+----
+true
+
+# a single-factor fit has an empty factors list
+query I
+SELECT len((glmm_fit_agg(y, [x], region)).factors) FROM crossed;
+----
+0
+
+statement ok
+DROP TABLE IF EXISTS crossed;
 
 statement ok
 DROP TABLE IF EXISTS singletons;


### PR DESCRIPTION
Implements the two #109 extensions to `glmm_fit_agg`, and moves the mixed-effects **model** onto the upstream `anofox_regression::GlmmRegressor` — this extension is now a DuckDB wrapper for GLMM, not a second implementation. The ~325-line downstream random-intercept solver is deleted; `fit_glmm` delegates upstream.

## New capabilities (SQL surface via the options MAP)

**Random slopes** — `{'random': [i, …]}` names 1-based feature columns that also carry a random slope, with an unstructured covariance with the intercept:
```sql
SELECT glmm_fit_agg(y, [x], grp, {'random': [1]}) FROM t;
-- result gains: random_cov DOUBLE[] (Sigma, flattened row-major) + random_dim INTEGER (q)
-- q=2 here; random_cov = [var_int, cov, cov, var_slope]
```

**Crossed / nested factors** — `{'groups': [j, …]}` names 1-based x-columns that are additional grouping factors (each dictionary-encoded, removed from the design, fitted via `fit_crossed`):
```sql
SELECT glmm_fit_agg(y, [x, region], grp, {'groups': [2]}) FROM t;
-- result gains: factors LIST(STRUCT(n_levels BIGINT, var DOUBLE)) -- per-factor variances
```
Nesting `(1|a/b)` is expressed by passing the composed `a:b` key as a factor column.

Plumbed core → FFI (options + result, multi-factor input) → header → options parser → C++ aggregate. New `fit_glmm_crossed` in core; `random_cov`/`random_dim`/`factors` result fields.

## Deliberate, temporary regressions (all tracked upstream in [anofox-regression#29](https://github.com/sipemu/anofox-regression/issues/29))
Surfaced as clear errors / NaN, not silent:
- NegBinomial / Gamma / Tweedie **mixed-effects** families (still available as plain GLM aggregates),
- the GLMM `offset`,
- per-group BLUP conditional standard errors (`ranef.se` is `NaN`),
- random slopes combined with multiple grouping factors.

## Not in this PR (documented follow-ups)
- Per-group slope/factor BLUP vectors (the FFI already carries `ranef_effects`; the aggregate currently surfaces Σ + the intercept BLUP + per-factor variances).

## Verification
- `cargo test`: 277 + 3.
- Full SQL suite: 2416 assertions / 98 cases (new random-slopes + crossed tests in `test_glmm.test`).
- Docs (`docs/api/glm/glmm.md`) updated for the new options, result fields, and limitations.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788287504&installation_model_id=425457&pr_number=118&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F118&signature=37820501841b155a10fd84d29c4809993a14429a13604a93280bc3677cb03259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->