### PR TITLE
fix(ci): satisfy clippy -D warnings on main (supersedes #115)

### DIFF
--- a/crates/anofox-stats-core/src/models/aft.rs
+++ b/crates/anofox-stats-core/src/models/aft.rs
@@ -408,7 +408,7 @@ fn newton(
 
         let mut step = crate::models::glm_engine::normal_eq::solve_qr(&build_info(0.0), &g, 1e-12)?;
         let mut decrement: f64 = (0..n_params).map(|j| grad[j] * step[j]).sum();
-        if !(decrement > 0.0) || !decrement.is_finite() {
+        if !decrement.is_finite() || decrement <= 0.0 {
             let mut damping = 1e-3;
             for _ in 0..20 {
                 step = crate::models::glm_engine::normal_eq::solve_qr(
@@ -422,7 +422,7 @@ fn newton(
                 }
                 damping *= 10.0;
             }
-            if !(decrement > 0.0) || !decrement.is_finite() {
+            if !decrement.is_finite() || decrement <= 0.0 {
                 // Even heavy damping did not produce an ascent direction; fall back
                 // to steepest ascent, normalised so the line search starts sanely.
                 let gnorm = grad.iter().fold(0.0_f64, |m, v| m.max(v.abs())).max(1e-300);

--- a/crates/anofox-stats-core/src/models/eb_shrink.rs
+++ b/crates/anofox-stats-core/src/models/eb_shrink.rs
@@ -37,20 +37,11 @@ pub enum TauMethod {
 }
 
 /// Options for empirical-Bayes shrinkage.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct EbShrinkOptions {
     pub method: TauMethod,
     /// A fixed `tau^2` instead of estimating one. Overrides `method` when set.
     pub tau_squared: Option<f64>,
-}
-
-impl Default for EbShrinkOptions {
-    fn default() -> Self {
-        Self {
-            method: TauMethod::default(),
-            tau_squared: None,
-        }
-    }
 }
 
 /// One group's shrunken estimate.

--- a/crates/anofox-stats-core/src/models/glm.rs
+++ b/crates/anofox-stats-core/src/models/glm.rs
@@ -617,7 +617,7 @@ mod tests {
         let fit = fit_poisson(&y, &x, &PoissonOptions::default()).unwrap();
         assert!((fit.core.intercept.unwrap() - 0.783_761_952_889_341_5).abs() < 1e-7);
         assert!((fit.core.coefficients[0] - 0.241_563_412_876_373_3).abs() < 1e-7);
-        assert!((fit.core.coefficients[1] + 0.128_771_260_171_794_0).abs() < 1e-7);
+        assert!((fit.core.coefficients[1] + 0.128_771_260_171_794).abs() < 1e-7);
     }
 
     #[test]
@@ -627,7 +627,7 @@ mod tests {
         let y: Vec<f64> = (0..n)
             .map(|i| f64::from(u8::from(0.8 * xs[i] + ((i % 3) as f64 - 1.0) * 0.5 > 0.0)))
             .collect();
-        let fit = fit_logistic(&y, &vec![xs], &LogisticOptions::default()).unwrap();
+        let fit = fit_logistic(&y, &[xs], &LogisticOptions::default()).unwrap();
         assert!((0.0..=1.0).contains(&fit.accuracy));
         assert!(fit.accuracy > 0.5, "accuracy {}", fit.accuracy);
     }

--- a/crates/anofox-stats-core/src/models/glm_engine/design.rs
+++ b/crates/anofox-stats-core/src/models/glm_engine/design.rs
@@ -446,7 +446,7 @@ mod tests {
         })
         .unwrap();
 
-        let err = d.build_penalty(&vec![PriorSpec::flat(); 7], 0.0);
+        let err = d.build_penalty(&[PriorSpec::flat(); 7], 0.0);
         assert!(matches!(err, Err(StatsError::InvalidInput(_))));
     }
 

--- a/crates/anofox-stats-core/src/models/glm_engine/loglik.rs
+++ b/crates/anofox-stats-core/src/models/glm_engine/loglik.rs
@@ -190,7 +190,7 @@ mod tests {
     fn poisson_matches_dpois() {
         // R: dpois(3, lambda = 2.5, log = TRUE) = -1.542887273605590
         let ll = unit_log_likelihood(LogLikKind::Poisson, 3.0, 2.5);
-        assert!((ll - (-1.542_887_273_605_590)).abs() < 1e-12, "got {ll}");
+        assert!((ll - (-1.542_887_273_605_59)).abs() < 1e-12, "got {ll}");
     }
 
     #[test]

--- a/crates/anofox-stats-core/src/models/glm_engine/parity.rs
+++ b/crates/anofox-stats-core/src/models/glm_engine/parity.rs
@@ -376,7 +376,7 @@ fn poisson_single_feature_matches_the_reference() {
         0.792_438_587_563_215_5,
         REF_TOL,
     );
-    assert_close("slope", fit.irls.beta[1], 0.238_180_118_325_312_0, REF_TOL);
+    assert_close("slope", fit.irls.beta[1], 0.238_180_118_325_312, REF_TOL);
     assert_close(
         "deviance",
         fit.irls.deviance,
@@ -426,7 +426,7 @@ fn poisson_two_feature_matches_the_reference() {
         REF_TOL,
     );
     assert_close("x1", fit.irls.beta[1], 0.241_563_412_876_373_3, REF_TOL);
-    assert_close("x2", fit.irls.beta[2], -0.128_771_260_171_794_0, REF_TOL);
+    assert_close("x2", fit.irls.beta[2], -0.128_771_260_171_794, REF_TOL);
     assert_close(
         "deviance",
         fit.irls.deviance,
@@ -445,7 +445,7 @@ fn poisson_two_feature_matches_the_reference() {
     assert_close(
         "intercept se",
         inf.std_errors[0],
-        0.151_817_171_836_096_0,
+        0.151_817_171_836_096,
         REF_TOL,
     );
     assert_close("x1 se", inf.std_errors[1], 0.078_215_310_636_067_5, REF_TOL);
@@ -537,7 +537,7 @@ fn tweedie_single_feature_matches_the_reference() {
         0.545_111_433_395_903_3,
         REF_TOL,
     );
-    assert_close("slope", fit.irls.beta[1], 0.233_128_099_664_133_0, REF_TOL);
+    assert_close("slope", fit.irls.beta[1], 0.233_128_099_664_133, REF_TOL);
     assert_close(
         "deviance",
         fit.irls.deviance,
@@ -584,7 +584,7 @@ fn negbinomial_single_feature_matches_the_reference() {
     assert_close(
         "slope se",
         inf.std_errors[1],
-        0.119_889_845_294_418_0,
+        0.119_889_845_294_418,
         REF_TOL,
     );
 }
@@ -744,7 +744,7 @@ fn constant_columns_are_dropped_and_reported_as_nan() {
     assert_eq!(res.coefficients.len(), 3);
     assert!(res.coefficients[0].is_nan(), "constant column must be NaN");
     assert_close("x1", res.coefficients[1], 0.241_563_412_876_373_3, REF_TOL);
-    assert_close("x2", res.coefficients[2], -0.128_771_260_171_794_0, REF_TOL);
+    assert_close("x2", res.coefficients[2], -0.128_771_260_171_794, REF_TOL);
 
     let inf = fit.to_glm_inference().unwrap();
     assert!(inf.std_errors[0].is_nan());

--- a/crates/anofox-stats-core/src/models/glmm.rs
+++ b/crates/anofox-stats-core/src/models/glmm.rs
@@ -777,7 +777,7 @@ mod tests {
                 let x = (j % 4) as f64;
                 y.push((0.5 + 0.3 * x + b).exp().round());
                 xs.push(x);
-                g.push(gi as i32);
+                g.push(gi);
             }
         }
         let opts = GlmmOptions {
@@ -785,7 +785,7 @@ mod tests {
             compute_inference: true,
             ..Default::default()
         };
-        let fit = fit_glmm(&y, &vec![xs], &g, &opts).unwrap();
+        let fit = fit_glmm(&y, &[xs], &g, &opts).unwrap();
 
         assert!(
             (fit.coefficients[0] - 0.3).abs() < 0.1,

--- a/crates/anofox-stats-ffi/src/lib.rs
+++ b/crates/anofox-stats-ffi/src/lib.rs
@@ -7327,7 +7327,7 @@ unsafe fn alloc_f64(values: &[f64]) -> *mut f64 {
     if values.is_empty() {
         return std::ptr::null_mut();
     }
-    let ptr = libc::malloc(std::mem::size_of::<f64>() * values.len()) as *mut f64;
+    let ptr = libc::malloc(std::mem::size_of_val(values)) as *mut f64;
     if !ptr.is_null() {
         std::ptr::copy_nonoverlapping(values.as_ptr(), ptr, values.len());
     }
@@ -7659,7 +7659,7 @@ unsafe fn alloc_i32(values: &[i32]) -> *mut i32 {
     if values.is_empty() {
         return std::ptr::null_mut();
     }
-    let ptr = libc::malloc(std::mem::size_of::<i32>() * values.len()) as *mut i32;
+    let ptr = libc::malloc(std::mem::size_of_val(values)) as *mut i32;
     if !ptr.is_null() {
         std::ptr::copy_nonoverlapping(values.as_ptr(), ptr, values.len());
     }
@@ -7670,7 +7670,7 @@ unsafe fn alloc_i64(values: &[i64]) -> *mut i64 {
     if values.is_empty() {
         return std::ptr::null_mut();
     }
-    let ptr = libc::malloc(std::mem::size_of::<i64>() * values.len()) as *mut i64;
+    let ptr = libc::malloc(std::mem::size_of_val(values)) as *mut i64;
     if !ptr.is_null() {
         std::ptr::copy_nonoverlapping(values.as_ptr(), ptr, values.len());
     }

--- a/crates/anofox-stats-ffi/src/types.rs
+++ b/crates/anofox-stats-ffi/src/types.rs
@@ -650,20 +650,15 @@ impl Default for PriorSpecFFI {
 // every field that follows it. Harmless while such a field sits last in a
 // struct, fatal when it sits first (AftOptionsFFI::dist).
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum VcovTypeFFI {
     /// `(X'WX + P)^-1`, the curvature of the log posterior at the mode.
+    #[default]
     Laplace = 0,
     /// `(X'WX + P)^-1 X'WX (X'WX + P)^-1`.
     Sandwich = 1,
     /// `(X'WX)^-1`, ignoring the penalty.
     Naive = 2,
-}
-
-impl Default for VcovTypeFFI {
-    fn default() -> Self {
-        VcovTypeFFI::Laplace
-    }
 }
 
 /// Prior and covariance settings carried by every GLM options struct.
@@ -2287,18 +2282,13 @@ impl Default for LmDynamicFitResultFFI {
 // every field that follows it. Harmless while such a field sits last in a
 // struct, fatal when it sits first (AftOptionsFFI::dist).
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AftDistributionFFI {
+    #[default]
     Weibull = 0,
     LogNormal = 1,
     LogLogistic = 2,
     Exponential = 3,
-}
-
-impl Default for AftDistributionFFI {
-    fn default() -> Self {
-        AftDistributionFFI::Weibull
-    }
 }
 
 /// Options for an AFT fit. Flat POD, like every other options struct here.
@@ -2426,17 +2416,12 @@ mod abi_tests {
 
 /// Between-group variance estimator.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TauMethodFFI {
+    #[default]
     DerSimonianLaird = 0,
     /// Complete pooling.
     None = 1,
-}
-
-impl Default for TauMethodFFI {
-    fn default() -> Self {
-        TauMethodFFI::DerSimonianLaird
-    }
 }
 
 /// Options for empirical-Bayes shrinkage.
@@ -2480,20 +2465,15 @@ pub struct EbShrinkResultFFI {
 
 /// Response family for a mixed-effects fit.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum GlmmFamilyFFI {
+    #[default]
     Gaussian = 0,
     Poisson = 1,
     Binomial = 2,
     NegativeBinomial = 3,
     Gamma = 4,
     Tweedie = 5,
-}
-
-impl Default for GlmmFamilyFFI {
-    fn default() -> Self {
-        GlmmFamilyFFI::Gaussian
-    }
 }
 
 /// Options for a mixed-effects fit.


### PR DESCRIPTION
`main`'s **Build and test Rust components** job runs `cargo clippy --all-targets --all-features -- -D warnings`, red since #108. This turns it green.

**Supersedes #115.** #115 fixed the same job but was cut against the pre-#116/#117/#118 tree and no longer applies: its `glmm.rs` hunks patch the downstream solver that #118 deleted, and it predates a new `i32 -> i32` cast #118 introduced. This applies the equivalent cleanup on current `main` (credit to @jrosskopf).

- **aft.rs** — two `!(decrement > 0.0)` negated comparisons on a partially-ordered type → `!decrement.is_finite() || decrement <= 0.0` (NaN case explicit).
- **Derivable `Default`** → `#[derive(Default)]` + `#[default]` for eb_shrink `TauMethod` and FFI enums `VcovTypeFFI`/`AftDistributionFFI`/`TauMethodFFI`/`GlmmFamilyFFI`. Verified each `#[default]` variant equals the manual impl's return (Laplace / Weibull / DerSimonianLaird / Gaussian) — **FFI defaults bit-identical**.
- **Mechanical** (`cargo clippy --fix`) — excessive float precision on parity reference constants (trailing-zero spelling only; every f64 bit-identical), `vec![]` → array, manual slice-size calcs, and the redundant same-type cast in `glmm.rs` from #118.

**Verification:** `cargo clippy -D warnings` clean · `cargo fmt --check` clean · cargo 277 + 3 · full SQL suite 2416 assertions / 98 cases.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788461668&installation_model_id=425457&pr_number=119&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F119&signature=fc022c0275d1a2363f602a83d8dbd3bcb79d4ddd1ac8cc829b2ccde1908ef223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->