### PR TITLE
Report the AFT covariance instead of only its diagonal

### DIFF
--- a/crates/anofox-stats-core/src/models/aft.rs
+++ b/crates/anofox-stats-core/src/models/aft.rs
@@ -99,6 +99,21 @@ pub struct AftInference {
     pub intercept_std_error: Option<f64>,
     /// Standard error of `log sigma`; `None` when the scale is fixed.
     pub log_scale_std_error: Option<f64>,
+    /// The full covariance of the fitted parameters at the mode, `None` when inference
+    /// was not requested.
+    ///
+    /// Indexed in the order the fit parameterises: the intercept first when one is
+    /// fitted, then the coefficients in feature order, then `log sigma` when the scale
+    /// is estimated. So for a fit with an intercept and `p` features the matrix is
+    /// `(1 + p + 1)` square, and `sqrt(vcov[(j, j)])` is the standard error this struct
+    /// reports for parameter `j`.
+    ///
+    /// Reported because the diagonal is not the whole answer. Anything that needs the
+    /// *joint* distribution -- a Laplace posterior to sample, a prediction interval on
+    /// a linear combination, a delta-method standard error -- would otherwise have to
+    /// rebuild this matrix from `AftDistribution`'s derivatives, re-differentiating a
+    /// likelihood this function has already differentiated.
+    pub vcov: Option<Mat<f64>>,
 }
 
 /// Fit an AFT model.
@@ -276,6 +291,7 @@ pub fn fit_aft(
             } else {
                 None
             },
+            vcov: Some(inf.vcov.clone()),
         })
     } else {
         None
@@ -798,6 +814,85 @@ mod tests {
             "intercept {} vs OLS {intercept}",
             fit.core.intercept.unwrap()
         );
+    }
+
+    /// **The curvature is reported, not just its diagonal.**
+    ///
+    /// `fit_aft` computes the full observed information at the mode and hands it to
+    /// `laplace::inference`, which returns the whole covariance matrix. Until now only
+    /// slices of the *diagonal* survived into `AftInference` -- `std_errors`,
+    /// `z_values`, the interval bounds -- and the off-diagonal was discarded on the way
+    /// out of the crate.
+    ///
+    /// That is a real loss rather than a tidy-up. Any consumer that needs the joint
+    /// distribution of the coefficients -- a Laplace posterior to sample from, a
+    /// prediction interval on a linear combination, a delta-method standard error --
+    /// has to reconstruct the matrix from `AftDistribution`'s public derivatives, which
+    /// means re-deriving the likelihood this function has already differentiated.
+    ///
+    /// So the matrix is part of the result. Its diagonal must reproduce the standard
+    /// errors this crate already reports, which is the assertion that keeps the two
+    /// from drifting apart.
+    #[test]
+    fn the_reported_curvature_agrees_with_the_standard_errors_it_summarises() {
+        for dist in [
+            AftDistribution::Weibull,
+            AftDistribution::LogNormal,
+            AftDistribution::LogLogistic,
+        ] {
+            let (time, x, event) = survival_fixture(dist, 1.5, 0.35, 0.6, 400, Some(0.3));
+            let opts = AftOptions {
+                dist,
+                compute_inference: true,
+                ..Default::default()
+            };
+            let fit = fit_aft(&time, &x, &event, &opts).unwrap();
+            let inf = fit.inference.as_ref().expect("inference was requested");
+            let vcov = inf.vcov.as_ref().expect("the covariance must be reported");
+
+            // Intercept first, then the coefficients, then log-scale: the order
+            // `fit_aft` fits in, and the order the matrix is indexed by.
+            let n_beta = 1 + 1; // intercept + one feature
+            assert_eq!(vcov.nrows(), n_beta + 1, "{dist:?} covariance is p x p");
+            assert_eq!(vcov.ncols(), vcov.nrows(), "{dist:?} covariance is square");
+
+            let se_of = |j: usize| vcov[(j, j)].sqrt();
+            assert!(
+                (se_of(0) - inf.intercept_std_error.unwrap()).abs() < 1e-9,
+                "{dist:?} intercept SE {} vs sqrt(vcov[0,0]) {}",
+                inf.intercept_std_error.unwrap(),
+                se_of(0)
+            );
+            assert!(
+                (se_of(1) - inf.std_errors[0]).abs() < 1e-9,
+                "{dist:?} slope SE {} vs sqrt(vcov[1,1]) {}",
+                inf.std_errors[0],
+                se_of(1)
+            );
+            assert!(
+                (se_of(2) - inf.log_scale_std_error.unwrap()).abs() < 1e-9,
+                "{dist:?} log-scale SE {} vs sqrt(vcov[2,2]) {}",
+                inf.log_scale_std_error.unwrap(),
+                se_of(2)
+            );
+
+            // Symmetric, and not diagonal: the off-diagonal is the part that was being
+            // thrown away, so a matrix that happened to be diagonal would prove nothing.
+            for r in 0..vcov.nrows() {
+                for c in 0..vcov.ncols() {
+                    assert!(
+                        (vcov[(r, c)] - vcov[(c, r)]).abs() < 1e-12,
+                        "{dist:?} covariance must be symmetric at ({r},{c})"
+                    );
+                }
+            }
+            assert!(
+                vcov[(0, 1)].abs() > 1e-12,
+                "{dist:?} intercept and slope must covary on a fixture whose \
+                 covariate is not centred; got {}",
+                vcov[(0, 1)]
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
`fit_aft` already computes the full observed information at the mode and hands it to `laplace::inference`, which returns the whole covariance matrix. `AftInference` kept only slices of the **diagonal** — `std_errors`, `z_values`, the interval bounds — and dropped the off-diagonal on the way out of the crate.

## Why this matters beyond tidiness

Anything that needs the *joint* distribution of the coefficients — a Laplace posterior to sample from, a prediction interval on a linear combination, a delta-method standard error — has to rebuild the matrix from `AftDistribution`'s public derivatives.

**A downstream consumer is doing exactly that today.** `anofox-bayes` bridges `fit_aft` into a Bayesian draws contract, and to do it carries ~85 lines that re-derive this Hessian per observation, plus ~45 more that re-implement this crate's private `build_penalty` to align the priors the same way, plus a cross-check asserting the reassembly reproduces `std_errors`. All of it exists only because the matrix is computed here and not returned.

## The change

`AftInference` gains `vcov: Option<Mat<f64>>`, populated from the `LaplaceInference` the function already builds. Documented with the parameter order it is indexed by: intercept first when fitted, then coefficients in feature order, then `log sigma` when the scale is estimated — so `sqrt(vcov[(j, j)])` is the standard error already reported for parameter `j`.

## Test

`the_reported_curvature_agrees_with_the_standard_errors_it_summarises`, across Weibull, lognormal and log-logistic on a censored fixture:

- the diagonal reproduces `intercept_std_error`, `std_errors[0]` and `log_scale_std_error` to 1e-9 — the assertion that stops the matrix and the summaries drifting apart;
- the matrix is symmetric;
- **and genuinely not diagonal** — the off-diagonal is the part that was being discarded, so a matrix that happened to be diagonal would prove nothing.

Written red first: it failed with `no field 'vcov' on AftInference`.

## Verification

`cargo test -p anofox-stats-core --lib` — 276 pass. `cargo fmt --all --check` clean. Clippy unchanged: 24 warnings on this branch and 24 on `main`, none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788495259&installation_model_id=425457&pr_number=120&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F120&signature=349b39d8bc6338db5880eb73b0f63fc55dba57d43f8719b2cdeee05fd8928f87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->