### PR TITLE
Fix the macOS and WASM builds: match the FFI's index type

### DIFF
--- a/src/aggregate_functions/glmm_aggregate.cpp
+++ b/src/aggregate_functions/glmm_aggregate.cpp
@@ -1,3 +1,4 @@
+#include <type_traits>
 #include <limits>
 #include <unordered_map>
 #include <vector>
@@ -13,6 +14,13 @@
 #include "telemetry.hpp"
 
 namespace duckdb {
+
+namespace {
+/// The index type `AnofoxGlmmOptions::random_slopes` points at, taken from the header
+/// rather than written out. See the note on the fields that use it.
+using RandomSlopeIndex = std::remove_const<std::remove_pointer<decltype(AnofoxGlmmOptions::random_slopes)>::type>::type;
+} // namespace
+
 
 //===--------------------------------------------------------------------===//
 // Mixed-effects GLM with a random intercept over one grouping factor.
@@ -44,7 +52,21 @@ struct GlmmAggregateState {
 	double power;
 	idx_t offset_column;
 	//! 0-based indices into x of columns that also carry a random slope.
-	vector<idx_t> random_slopes;
+	// The element type is *derived from* the FFI declaration rather than restated, so
+	// the two cannot drift.
+	//
+	// Restating it is what broke every non-Linux build: this held `idx_t` while
+	// `AnofoxGlmmOptions::random_slopes` is `const size_t *`. On Linux those are the
+	// same *type* -- both `unsigned long` -- so `.data()` assigned cleanly and every
+	// Linux job stayed green. On macOS and on wasm32 they are distinct types, and it
+	// is a hard error. The same line failed the macOS and all three DuckDB-Wasm jobs,
+	// and the deploys that depend on them.
+	//
+	// A `static_assert` here would not have helped, and that was measured rather than
+	// assumed: asserting the two types are the same passes on Linux, because on Linux
+	// they are. Deriving the type is the only form of the check that means anything on
+	// the platform where the mistake is invisible.
+	vector<RandomSlopeIndex> random_slopes;
 	//! 0-based indices into x of additional crossed grouping-factor columns.
 	vector<idx_t> group_columns;
 
@@ -87,7 +109,21 @@ struct GlmmAggregateBindData : public FunctionData {
 	double theta = 1.0;
 	double power = 1.5;
 	idx_t offset_column = 0;
-	vector<idx_t> random_slopes;
+	// The element type is *derived from* the FFI declaration rather than restated, so
+	// the two cannot drift.
+	//
+	// Restating it is what broke every non-Linux build: this held `idx_t` while
+	// `AnofoxGlmmOptions::random_slopes` is `const size_t *`. On Linux those are the
+	// same *type* -- both `unsigned long` -- so `.data()` assigned cleanly and every
+	// Linux job stayed green. On macOS and on wasm32 they are distinct types, and it
+	// is a hard error. The same line failed the macOS and all three DuckDB-Wasm jobs,
+	// and the deploys that depend on them.
+	//
+	// A `static_assert` here would not have helped, and that was measured rather than
+	// assumed: asserting the two types are the same passes on Linux, because on Linux
+	// they are. Deriving the type is the only form of the check that means anything on
+	// the platform where the mistake is invisible.
+	vector<RandomSlopeIndex> random_slopes;
 	vector<idx_t> group_columns;
 
 	unique_ptr<FunctionData> Copy() const override {


### PR DESCRIPTION
Every non-Linux build on `main` has been failing, and all of them on **one line**.

`glmm_aggregate.cpp` held `vector<idx_t> random_slopes` and passed its `.data()` to `AnofoxGlmmOptions::random_slopes`, which the FFI header declares as `const size_t *`.

On Linux those are the same *type* — both `unsigned long` — so the assignment compiled and every Linux job stayed green. On macOS and on wasm32 they are distinct types, and it is a hard error:

```
glmm_aggregate.cpp:379:27: error: incompatible pointer types assigning to
'const size_t *' (aka 'const unsigned long *') from 'value_type *' (aka 'unsigned long long *')
```

That single line accounts for the macOS job, **all three DuckDB-Wasm jobs**, and the five deploy jobs depending on them — on both DuckDB versions.

## The fix

The element type is now **derived** from the FFI declaration rather than restated:

```cpp
using RandomSlopeIndex =
    std::remove_const<std::remove_pointer<decltype(AnofoxGlmmOptions::random_slopes)>::type>::type;
```

so the container and the contract cannot drift apart on any platform.

## Why not a `static_assert`

I tried that first, and it does not work — measured, not assumed. I wrote an assertion that the container's `value_type` matches the FFI's pointee, put the wrong type back, and **the Linux build stayed green**: on Linux the two types genuinely are the same, which is exactly why the bug reached `main` in the first place. No assertion evaluated on Linux can see this. Deriving the type is the only form of the check that means anything on the platforms where the mistake is invisible.

## Verification

`make release` clean, `make test` — **2416 assertions in 98 test cases** pass. The macOS and Wasm jobs cannot be run locally; this PR's own CI is the check.

## Note

Found while investigating why #120 and #121 were red. They are red for this reason, not their own — `main` fails the identical set of jobs. Both should be rebased once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788500280&installation_model_id=425457&pr_number=122&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F122&signature=a04d653cdc3d9e759a91696a0737a3ef4e8fccbff2334173420d0453c8066a78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->