### PR TITLE
fix(glmm): use size_t for random_slopes to build on macOS/wasm (#109)

### DIFF
--- a/src/aggregate_functions/glmm_aggregate.cpp
+++ b/src/aggregate_functions/glmm_aggregate.cpp
@@ -44,7 +44,9 @@ struct GlmmAggregateState {
 	double power;
 	idx_t offset_column;
 	//! 0-based indices into x of columns that also carry a random slope.
-	vector<idx_t> random_slopes;
+	// size_t (not idx_t) to match the FFI's `const size_t *` on every platform:
+	// on macOS/wasm idx_t (uint64_t) is a distinct type/width from size_t.
+	vector<size_t> random_slopes;
 	//! 0-based indices into x of additional crossed grouping-factor columns.
 	vector<idx_t> group_columns;
 
@@ -87,7 +89,9 @@ struct GlmmAggregateBindData : public FunctionData {
 	double theta = 1.0;
 	double power = 1.5;
 	idx_t offset_column = 0;
-	vector<idx_t> random_slopes;
+	// size_t (not idx_t) to match the FFI's `const size_t *` on every platform:
+	// on macOS/wasm idx_t (uint64_t) is a distinct type/width from size_t.
+	vector<size_t> random_slopes;
 	vector<idx_t> group_columns;
 
 	unique_ptr<FunctionData> Copy() const override {
@@ -505,7 +509,7 @@ static unique_ptr<FunctionData> GlmmAggBind(ClientContext &context, AggregateFun
 		if (opts.random_slopes.has_value()) {
 			// Options carry 1-based indices; the core/FFI want 0-based.
 			for (auto idx1 : opts.random_slopes.value()) {
-				result->random_slopes.push_back(idx1 - 1);
+				result->random_slopes.push_back((size_t)(idx1 - 1));
 			}
 		}
 		if (opts.group_columns.has_value()) {


### PR DESCRIPTION
`glmm_aggregate.cpp` stored `random_slopes` as `vector<idx_t>` but the FFI option is `const size_t *`. On Linux `idx_t`(uint64_t)==`size_t`, so it compiled; on **macOS** they're distinct types and on **wasm32** different widths, so `.data()` → `const size_t *` failed with *incompatible pointer types*. This broke the macOS + all WASM builds — which is why **v0.8.0's mac/wasm binaries never published** (community-extensions #2437 and our own v0.8.0 pipeline both fail there), while Linux/Windows/local were green.

Fix: store `random_slopes` as `vector<size_t>` (matches the FFI/`usize` contract on every platform); parse casts the 1-based `idx_t` option explicitly. No behavior change.

Verified locally: `make release` + `test_glmm.test` (48 assertions). The real proof is the mac/wasm CI legs, which should now compile.

Follows #118 (#109). Needs a v0.8.1 re-cut afterward, since v0.8.0 is incomplete on mac/wasm.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788502078&installation_model_id=425457&pr_number=123&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F123&signature=42bfecd456527d5954e0b6b3001e96c7e01156aacefb2bf5063439e2cfa505f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->