### PR TITLE
Disable telemetry in CI

### DIFF
--- a/.github/workflows/ExtensionTemplate.yml
+++ b/.github/workflows/ExtensionTemplate.yml
@@ -8,6 +8,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true
 
+
+# Telemetry off: this workflow builds and tests an extension, and the extension
+# records a PostHog event per function call. See MainDistributionPipeline.yml for why
+# `is_ci` is not sufficient on its own.
+env:
+  DATAZOO_DISABLE_TELEMETRY: "1"
+
 jobs:
   linux:
     name: Linux

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -7,6 +7,31 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Telemetry off for everything CI runs.
+#
+# The extension records a PostHog event per function call, and the suite exercises
+# thousands of them on every push -- so a green pipeline was publishing a spike of
+# usage that looks exactly like a customer.
+#
+# `is_ci` does not prevent this. It is a *tag* on the event envelope, and it is not
+# even set correctly on the platform that does most of the testing: the Linux jobs run
+# inside a container that receives only the variables extension-ci-tools writes into
+# `docker_env.txt`, and none of the eight names `ComputeCI()` looks for -- `CI`,
+# `GITHUB_ACTIONS` and friends -- are among them. So those events arrived tagged
+# `is_ci: false`, indistinguishable from real traffic.
+#
+# `DATAZOO_DISABLE_TELEMETRY` is the switch that actually stops egress:
+# `PostHogProcessBatch` is documented as the only place that touches the network and
+# returns early when it is set. It is read per batch rather than cached at startup, so
+# it takes effect wherever it is set.
+#
+# This block covers the jobs defined here. The reusable-workflow jobs cannot inherit it
+# -- a called workflow gets no env from its caller -- so they pass it through
+# `test_config.test_env_variables`, which extension-ci-tools applies both to
+# `docker_env.txt` and to the native test steps.
+env:
+  DATAZOO_DISABLE_TELEMETRY: "1"
+
 # OIDC token needed for AWS credentials in the deploy job.
 permissions:
   id-token: write
@@ -22,6 +47,9 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
       duckdb_version: v1.5.5
+      # See the `env:` note at the top: a called workflow inherits no env, so the
+      # opt-out reaches the docker env file and the native test steps through here.
+      test_config: '{"test_env_variables": {"DATAZOO_DISABLE_TELEMETRY": "1"}}'
       ci_tools_version: v1.5-variegata
       extension_name: anofox_statistics
       enable_rust: true
@@ -61,6 +89,9 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.4-andium
     with:
       duckdb_version: v1.4.5
+      # See the `env:` note at the top: a called workflow inherits no env, so the
+      # opt-out reaches the docker env file and the native test steps through here.
+      test_config: '{"test_env_variables": {"DATAZOO_DISABLE_TELEMETRY": "1"}}'
       ci_tools_version: v1.4-andium
       extension_name: anofox_statistics
       enable_rust: true


### PR DESCRIPTION
CI has been publishing telemetry that looks like customer usage. This turns it off.

## What was happening

The extension records a PostHog event per function call — **111 emit sites** in `src/` — and `make test` runs **2416 assertions across 98 test cases**. Multiply by two DuckDB versions, several platforms, and every push and PR.

## Why `is_ci` did not prevent it

`is_ci` is a **tag on the event envelope** (`telemetry.cpp:650`), not a kill switch. Events are still sent; they are only labelled.

And on the platform that does most of the testing, the label is wrong. `ComputeCI()` looks for eight names — `CI`, `GITHUB_ACTIONS`, `GITLAB_CI`, `BUILDKITE`, `JENKINS_URL`, `TEAMCITY_VERSION`, `TF_BUILD`, `CIRCLECI`. The Linux jobs run **inside a container**, which receives only what `extension-ci-tools` writes into `docker_env.txt` (`_extension_distribution.yml:369-395`), and **none of those eight are in it**. It writes `LINUX_CI_IN_DOCKER=1`, which the detection does not look for.

So those events arrived tagged `is_ci: false` — indistinguishable from real traffic. macOS and Windows run natively and were tagged correctly; it is specifically the containerised Linux jobs, the ones that run the suite, that were mislabelled.

## Why `DATAZOO_DISABLE_TELEMETRY` is the right switch

`PostHogProcessBatch` is documented as *"the only place that touches the network"* and returns early when the variable is set. It is read **per batch** rather than cached at startup, so it takes effect wherever it is set — no ordering hazard. That makes it a guarantee of no egress, not a reduction in volume.

## Set two ways, because one does not reach everything

- **Workflow-level `env:`** covers the jobs defined in these files (the Rust job, the template jobs).
- **`test_config.test_env_variables`** for the two reusable-workflow build jobs — a called workflow inherits **no** env from its caller. `extension-ci-tools` applies that input in four places: `docker_env.txt` for the Linux containers, and an `export` before the native test steps on macOS, Windows and WASM.

## Follow-up, not in this PR

`posthog-telemetry` should add `LINUX_CI_IN_DOCKER` to `ComputeCI()`, so a container is recognised as CI even when a repository forgets this configuration. **That fixes the tag; this fixes the traffic.** They are worth having both.

`anofox-bayes` has the identical gap and needs the same change.

## Verification

Both workflow files parse (`yaml.safe_load`), and the extension runs clean with the variable set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788504552&installation_model_id=425457&pr_number=124&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F124&signature=ce4149e4caa967430b57928700feb0eb122934c7eb6ab45441ac96957b1da553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->