### PR TITLE
Report the AFT observed information alongside the covariance

### DIFF
--- a/crates/anofox-stats-core/src/models/aft.rs
+++ b/crates/anofox-stats-core/src/models/aft.rs
@@ -114,6 +114,19 @@ pub struct AftInference {
     /// rebuild this matrix from `AftDistribution`'s derivatives, re-differentiating a
     /// likelihood this function has already differentiated.
     pub vcov: Option<Mat<f64>>,
+    /// The penalised observed information at the mode -- the inverse of [`Self::vcov`]
+    /// -- in the same parameter order, `None` when inference was not requested.
+    ///
+    /// Both are reported because they answer different questions and each is awkward
+    /// to get from the other. `vcov` is what a report reads. The information is what a
+    /// *sampler* reads: drawing from the Laplace approximation factorises the
+    /// curvature, and recovering it by inverting `vcov` is a round trip through a
+    /// matrix this function already holds.
+    ///
+    /// "Penalised" is the operative word: it includes the contribution of any
+    /// [`PriorSpec`] supplied, so it is the curvature of the log *posterior* at the
+    /// mode rather than of the log likelihood.
+    pub information: Option<Mat<f64>>,
 }
 
 /// Fit an AFT model.
@@ -292,6 +305,7 @@ pub fn fit_aft(
                 None
             },
             vcov: Some(inf.vcov.clone()),
+            information: Some(state.information.clone()),
         })
     } else {
         None
@@ -833,6 +847,59 @@ mod tests {
     /// So the matrix is part of the result. Its diagonal must reproduce the standard
     /// errors this crate already reports, which is the assertion that keeps the two
     /// from drifting apart.
+    /// **The curvature itself, not only its inverse.**
+    ///
+    /// `vcov` answers "how uncertain", which is what a report wants. A consumer that
+    /// *samples* the Laplace approximation wants the other one: the observed
+    /// information is what a Cholesky factorises to draw from the Gaussian, and
+    /// recovering it by inverting `vcov` is a round trip through a matrix this
+    /// function already has in hand.
+    ///
+    /// `anofox-bayes` is that consumer, and until this existed it rebuilt the matrix
+    /// from `AftDistribution`'s derivatives per observation -- re-differentiating a
+    /// likelihood already differentiated here.
+    #[test]
+    fn the_reported_information_is_the_inverse_of_the_reported_covariance() {
+        for dist in [
+            AftDistribution::Weibull,
+            AftDistribution::LogNormal,
+            AftDistribution::LogLogistic,
+        ] {
+            let (time, x, event) = survival_fixture(dist, 1.5, 0.35, 0.6, 400, Some(0.3));
+            let opts = AftOptions {
+                dist,
+                compute_inference: true,
+                ..Default::default()
+            };
+            let fit = fit_aft(&time, &x, &event, &opts).unwrap();
+            let inf = fit.inference.as_ref().expect("inference was requested");
+            let info = inf
+                .information
+                .as_ref()
+                .expect("the observed information must be reported");
+            let vcov = inf.vcov.as_ref().expect("the covariance must be reported");
+
+            assert_eq!(info.nrows(), vcov.nrows(), "{dist:?} same shape");
+            // information * vcov = I, which is the whole claim about what it is.
+            let n = info.nrows();
+            for r in 0..n {
+                for c in 0..n {
+                    let entry: f64 = (0..n).map(|k| info[(r, k)] * vcov[(k, c)]).sum();
+                    let want = if r == c { 1.0 } else { 0.0 };
+                    assert!(
+                        (entry - want).abs() < 1e-8,
+                        "{dist:?}: (information * vcov)[{r},{c}] = {entry}, expected {want}"
+                    );
+                }
+            }
+            // Penalised, not naive: the diagonal must exceed nothing in particular,
+            // but it must be symmetric and positive on the diagonal to be a curvature.
+            for j in 0..n {
+                assert!(info[(j, j)] > 0.0, "{dist:?}: information diagonal {j}");
+            }
+        }
+    }
+
     #[test]
     fn the_reported_curvature_agrees_with_the_standard_errors_it_summarises() {
         for dist in [


### PR DESCRIPTION
Follow-up to #120, which exposed `vcov` but not the curvature it inverts.

## Why both

They answer different questions and each is awkward to get from the other:

- **`vcov`** — "how uncertain is this coefficient". What a report reads.
- **`information`** — what a *sampler* reads. Drawing from a Laplace approximation factorises the curvature, and recovering it by inverting `vcov` is a round trip through a matrix `fit_aft` already holds in `state.information`.

`anofox-bayes` is that consumer. Its bridge **still** rebuilds this matrix from `AftDistribution`'s derivatives, walking every observation to re-differentiate a likelihood this function has already differentiated — and only because the result was not reported. #120 got it halfway there; this closes the gap so the reassembly can be deleted rather than merely duplicated more cheaply.

## Penalised, and documented as such

It includes any `PriorSpec` contribution, so it is the curvature of the log *posterior* at the mode, not of the log likelihood. That is the distinction a MAP-plus-Laplace consumer depends on, and getting it silently wrong would produce a plausible, wrong posterior.

## Test

Asserts the defining property rather than a value: **`information × vcov = I`** to 1e-8 across Weibull, lognormal and log-logistic, plus a positive diagonal. Written red first — it failed with `no field 'information' on AftInference`.

## Verification

`cargo test -p anofox-stats-core --lib` — **287 pass**. `cargo fmt --all --check` clean, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788586396&installation_model_id=425457&pr_number=126&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F126&signature=997f50ca7b121d4c6319171ef15a1e8e839eceecaea0be72d2cc3fc42125a52f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->