### PR TITLE
feat: add feedback banner and issue links to fit errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "posthog-telemetry"]
 	path = posthog-telemetry
 	url = https://github.com/DataZooDE/posthog-telemetry.git
+[submodule "datazoo-banner"]
+	path = datazoo-banner
+	url = https://github.com/DataZooDE/duckdb-extension-banner.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,15 @@ else()
     set(ANOFOX_TELEMETRY_ENABLED OFF)
 endif()
 
+# Feedback banner (header-only, no dependencies of its own). Its banner_shown
+# event goes through posthog-telemetry, so the flag follows whether telemetry is
+# actually compiled in -- on MinGW it is not, and the banner header would then
+# include a telemetry.hpp that is not on the path.
+set(DATAZOO_BANNER_TELEMETRY ${ANOFOX_TELEMETRY_ENABLED} CACHE BOOL "" FORCE)
+set(DATAZOO_BANNER_TELEMETRY_INCLUDE_DIR
+    ${CMAKE_CURRENT_SOURCE_DIR}/posthog-telemetry/include CACHE PATH "" FORCE)
+add_subdirectory(datazoo-banner)
+
 include_directories(src/include)
 
 # Extension source files
@@ -215,8 +224,8 @@ build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
 build_loadable_extension(${TARGET_NAME} " " ${EXTENSION_SOURCES})
 
 # Link to Rust library
-target_link_libraries(${EXTENSION_NAME} anofox_stats_ffi-static)
-target_link_libraries(${LOADABLE_EXTENSION_NAME} anofox_stats_ffi-static)
+target_link_libraries(${EXTENSION_NAME} anofox_stats_ffi-static datazoo_banner)
+target_link_libraries(${LOADABLE_EXTENSION_NAME} anofox_stats_ffi-static datazoo_banner)
 
 # Telemetry header is always needed (provides no-op stubs when telemetry is disabled)
 target_include_directories(${EXTENSION_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/posthog-telemetry/include)

--- a/README.md
+++ b/README.md
@@ -304,6 +304,17 @@ For questions, open an issue on GitHub.
 - **Discussions**: [GitHub Discussions](https://github.com/DataZooDE/anofox-statistics/discussions)
 - **Email**: contact@datazoo.de
 
+If a fit misbehaves or a result looks wrong, please open an issue — regression against
+real data has failure modes we cannot reproduce from synthetic tests, so a report with
+your data shape is the fastest path to a fix. Errors from the fit and predict functions
+end with that link.
+
+If it saved you time, a star on the repo helps other people find it.
+
+The first time you load the extension in an interactive terminal each day, a small
+banner says the same thing. It never prints when output is piped, in notebooks, or in
+CI. Silence it with `SET datazoo_banner = false;` or `DATAZOO_NO_BANNER=1`.
+
 ## Citation
 
 If you use this extension in research, please cite:

--- a/src/anofox_statistics_extension.cpp
+++ b/src/anofox_statistics_extension.cpp
@@ -5,6 +5,21 @@
 #include "duckdb.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "telemetry.hpp"
+#include "anofox_statistics_banner.hpp"
+
+// The build stamps EXT_VERSION_ANOFOX_STATISTICS from the git tag; the fallback
+// matches what SetProduct reports below.
+#ifdef EXT_VERSION_ANOFOX_STATISTICS
+#define ANOFOX_STATISTICS_BANNER_VERSION EXT_VERSION_ANOFOX_STATISTICS
+#else
+#define ANOFOX_STATISTICS_BANNER_VERSION "0.1.0"
+#endif
+
+// Deliberately outside namespace duckdb: the banner library is DuckDB-agnostic
+// and the guard macro refers to this object from every guarded source file.
+const datazoo::BannerInfo ANOFOX_STATISTICS_BANNER {
+    "anofox_statistics", ANOFOX_STATISTICS_BANNER_VERSION,
+    "https://github.com/DataZooDE/anofox-statistics"};
 
 namespace duckdb {
 
@@ -199,6 +214,11 @@ void LoadInternal(ExtensionLoader &loader) {
 
     // Register table macros for fit_predict_by functions
     RegisterFitPredictTableMacros(loader);
+
+    datazoo::RegisterBannerOption(loader);
+    // Last, so a load that fails earlier never advertises itself. Silent unless
+    // stderr is a terminal and the ~/.duckdb stamp is over a day old.
+    datazoo::ShowBanner(ANOFOX_STATISTICS_BANNER);
 }
 
 void AnofoxStatisticsExtension::Load(ExtensionLoader &loader) {

--- a/src/include/anofox_statistics_banner.hpp
+++ b/src/include/anofox_statistics_banner.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "datazoo_banner_duckdb.hpp"
+
+// Shared identity for the load banner and the issue-link error footer.
+//
+// External linkage on purpose: DATAZOO_GUARD takes the address as a non-type
+// template argument, and every guarded translation unit should annotate errors
+// against the same object rather than a per-TU copy.
+//
+// Defined in anofox_statistics_extension.cpp.
+extern const datazoo::BannerInfo ANOFOX_STATISTICS_BANNER;

--- a/src/table_functions/elasticnet_fit.cpp
+++ b/src/table_functions/elasticnet_fit.cpp
@@ -13,6 +13,7 @@
 #include "../include/ffi_enum_converters.hpp"
 #include "../include/map_options_parser.hpp"
 #include "telemetry.hpp"
+#include "anofox_statistics_banner.hpp"
 
 namespace duckdb {
 
@@ -207,12 +208,14 @@ void RegisterElasticNetFitFunction(ExtensionLoader &loader) {
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
         LogicalType::ANY,
-        ElasticNetFitFunction, ElasticNetFitBind);
+        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, ElasticNetFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, ElasticNetFitBind));
 
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
                              LogicalType::ANY},
-                            LogicalType::ANY, ElasticNetFitFunction, ElasticNetFitBind);
+                            LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, ElasticNetFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, ElasticNetFitBind));
 
     // Primary
     {

--- a/src/table_functions/huber_fit.cpp
+++ b/src/table_functions/huber_fit.cpp
@@ -12,6 +12,7 @@
 #include "../include/ffi_enum_converters.hpp"
 #include "../include/map_options_parser.hpp"
 #include "telemetry.hpp"
+#include "anofox_statistics_banner.hpp"
 
 namespace duckdb {
 
@@ -236,11 +237,13 @@ static void HuberFitFunction(DataChunk &args, ExpressionState &state, Vector &re
 void RegisterHuberFitFunction(ExtensionLoader &loader) {
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
-        LogicalType::ANY, HuberFitFunction, HuberFitBind);
+        LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, HuberFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, HuberFitBind));
 
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::ANY},
-                            LogicalType::ANY, HuberFitFunction, HuberFitBind);
+                            LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, HuberFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, HuberFitBind));
 
     {
         ScalarFunctionSet func_set("anofox_stats_huber_fit");

--- a/src/table_functions/ols_fit.cpp
+++ b/src/table_functions/ols_fit.cpp
@@ -13,6 +13,7 @@
 #include "../include/ffi_enum_converters.hpp"
 #include "../include/map_options_parser.hpp"
 #include "telemetry.hpp"
+#include "anofox_statistics_banner.hpp"
 
 namespace duckdb {
 
@@ -236,12 +237,14 @@ void RegisterOlsFitFunction(ExtensionLoader &loader) {
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
         LogicalType::ANY,
-        OlsFitFunction, OlsFitBind);
+        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, OlsFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, OlsFitBind));
 
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
                              LogicalType::ANY},
-                            LogicalType::ANY, OlsFitFunction, OlsFitBind);
+                            LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, OlsFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, OlsFitBind));
 
     // Primary
     {

--- a/src/table_functions/predict.cpp
+++ b/src/table_functions/predict.cpp
@@ -10,6 +10,7 @@
 
 #include "../include/anofox_stats_ffi.h"
 #include "telemetry.hpp"
+#include "anofox_statistics_banner.hpp"
 
 namespace duckdb {
 
@@ -110,7 +111,8 @@ static void PredictFunction(DataChunk &args, ExpressionState &state, Vector &res
 void RegisterPredictFunction(ExtensionLoader &loader) {
     ScalarFunction func({LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
                          LogicalType::LIST(LogicalType::DOUBLE), LogicalType::DOUBLE},
-                        LogicalType::LIST(LogicalType::DOUBLE), PredictFunction);
+                        LogicalType::LIST(LogicalType::DOUBLE),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, PredictFunction));
 
     ScalarFunctionSet func_set("anofox_stats_predict");
     func_set.AddFunction(func);

--- a/src/table_functions/ransac_fit.cpp
+++ b/src/table_functions/ransac_fit.cpp
@@ -12,6 +12,7 @@
 #include "../include/ffi_enum_converters.hpp"
 #include "../include/map_options_parser.hpp"
 #include "telemetry.hpp"
+#include "anofox_statistics_banner.hpp"
 
 namespace duckdb {
 
@@ -266,11 +267,13 @@ static void RansacFitFunction(DataChunk &args, ExpressionState &state, Vector &r
 void RegisterRansacFitFunction(ExtensionLoader &loader) {
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
-        LogicalType::ANY, RansacFitFunction, RansacFitBind);
+        LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RansacFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RansacFitBind));
 
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::ANY},
-                            LogicalType::ANY, RansacFitFunction, RansacFitBind);
+                            LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RansacFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RansacFitBind));
 
     {
         ScalarFunctionSet func_set("anofox_stats_ransac_fit");

--- a/src/table_functions/ridge_fit.cpp
+++ b/src/table_functions/ridge_fit.cpp
@@ -13,6 +13,7 @@
 #include "../include/ffi_enum_converters.hpp"
 #include "../include/map_options_parser.hpp"
 #include "telemetry.hpp"
+#include "anofox_statistics_banner.hpp"
 
 namespace duckdb {
 
@@ -245,12 +246,14 @@ void RegisterRidgeFitFunction(ExtensionLoader &loader) {
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
         LogicalType::ANY,
-        RidgeFitFunction, RidgeFitBind);
+        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RidgeFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RidgeFitBind));
 
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
                              LogicalType::ANY},
-                            LogicalType::ANY, RidgeFitFunction, RidgeFitBind);
+                            LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RidgeFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RidgeFitBind));
 
     // Primary
     {

--- a/src/table_functions/rls_fit.cpp
+++ b/src/table_functions/rls_fit.cpp
@@ -12,6 +12,7 @@
 #include "../include/anofox_stats_ffi.h"
 #include "../include/map_options_parser.hpp"
 #include "telemetry.hpp"
+#include "anofox_statistics_banner.hpp"
 
 namespace duckdb {
 
@@ -188,12 +189,14 @@ void RegisterRlsFitFunction(ExtensionLoader &loader) {
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
         LogicalType::ANY,
-        RlsFitFunction, RlsFitBind);
+        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RlsFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RlsFitBind));
 
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
                              LogicalType::ANY},
-                            LogicalType::ANY, RlsFitFunction, RlsFitBind);
+                            LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RlsFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, RlsFitBind));
 
     // Primary
     {

--- a/src/table_functions/theil_sen_fit.cpp
+++ b/src/table_functions/theil_sen_fit.cpp
@@ -12,6 +12,7 @@
 #include "../include/ffi_enum_converters.hpp"
 #include "../include/map_options_parser.hpp"
 #include "telemetry.hpp"
+#include "anofox_statistics_banner.hpp"
 
 namespace duckdb {
 
@@ -240,11 +241,13 @@ static void TheilSenFitFunction(DataChunk &args, ExpressionState &state, Vector 
 void RegisterTheilSenFitFunction(ExtensionLoader &loader) {
     ScalarFunction basic_func(
         {LogicalType::LIST(LogicalType::DOUBLE), LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE))},
-        LogicalType::ANY, TheilSenFitFunction, TheilSenFitBind);
+        LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, TheilSenFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, TheilSenFitBind));
 
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)), LogicalType::ANY},
-                            LogicalType::ANY, TheilSenFitFunction, TheilSenFitBind);
+                            LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, TheilSenFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, TheilSenFitBind));
 
     {
         ScalarFunctionSet func_set("anofox_stats_theilsen_fit");

--- a/src/table_functions/wls_fit.cpp
+++ b/src/table_functions/wls_fit.cpp
@@ -13,6 +13,7 @@
 #include "../include/ffi_enum_converters.hpp"
 #include "../include/map_options_parser.hpp"
 #include "telemetry.hpp"
+#include "anofox_statistics_banner.hpp"
 
 namespace duckdb {
 
@@ -246,12 +247,14 @@ void RegisterWlsFitFunction(ExtensionLoader &loader) {
                                LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
                                LogicalType::LIST(LogicalType::DOUBLE)},
                               LogicalType::ANY,
-                              WlsFitFunction, WlsFitBind);
+                              DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, WlsFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, WlsFitBind));
     ScalarFunction map_func({LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::LIST(LogicalType::LIST(LogicalType::DOUBLE)),
                              LogicalType::LIST(LogicalType::DOUBLE),
                              LogicalType::ANY},
-                            LogicalType::ANY, WlsFitFunction, WlsFitBind);
+                            LogicalType::ANY, DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, WlsFitFunction),
+                        DATAZOO_GUARD(ANOFOX_STATISTICS_BANNER, WlsFitBind));
 
     // Primary
     {

--- a/test/sql/feedback.test
+++ b/test/sql/feedback.test
@@ -1,0 +1,40 @@
+# name: test/sql/feedback.test
+# description: The feedback banner's two contracts: errors from user-facing entry
+#              points carry an issue link, and the banner never writes anything
+#              under a test runner.
+# group: [sql]
+
+require anofox_statistics
+
+# --- Errors from the user-facing fit/predict entry points pick up the issue
+#     link, so a user who hits one is told where to report it. The guards sit at
+#     those registration sites only -- not on internal aggregate combine paths,
+#     which users do not invoke directly.
+statement error
+SELECT anofox_stats_ols_fit([1.0, 2.0], [[1.0]]);
+----
+https://github.com/DataZooDE/anofox-statistics/issues
+
+# The link is appended, not substituted: the real diagnostic must survive, and
+# it is the diagnostic from the Rust core that crossed the FFI boundary.
+statement error
+SELECT anofox_stats_ols_fit([1.0, 2.0], [[1.0]]);
+----
+Dimension mismatch
+
+# --- Errors DuckDB raises before dispatch (binder, catalog, arity) are
+#     deliberately NOT annotated -- they are not ours, and claiming them would
+#     send users to the wrong tracker.
+statement error
+SELECT anofox_stats_ols_fit();
+----
+Binder Error
+
+# --- The opt-out knob exists and is settable. The banner itself cannot be
+#     observed from a .test file at all -- stderr is not a tty here, which is
+#     precisely the guarantee that keeps this suite's expected output unchanged.
+statement ok
+SET datazoo_banner = false;
+
+statement ok
+SET datazoo_banner = true;


### PR DESCRIPTION
Regression against real data has failure modes we cannot reproduce from synthetic tests, so the users who hit a bad fit are the only ones who can tell us what the data looked like.

Part of a fleet-wide rollout using the shared [`DataZooDE/duckdb-extension-banner`](https://github.com/DataZooDE/duckdb-extension-banner) submodule. Same family as erpl-adt#36 (merged), [erpl-tunnel#2](https://github.com/DataZooDE/erpl-tunnel/pull/2), [quack-oauth#12](https://github.com/DataZooDE/quack-oauth/pull/12), [erpl-idoc#7](https://github.com/DataZooDE/erpl-idoc/pull/7), [erpl-rev#63](https://github.com/DataZooDE/erpl-rev/pull/63).

## What changed

**Once-a-day banner on interactive load.** Silent when piped, in notebooks, in CI, and under the test runner — which is why no existing expected output changes.

**Issue link on errors from the user-facing entry points** — the eight `*_fit` functions and `predict` — via `DATAZOO_GUARD` at their registration sites.

```
Invalid Input Error: OLS fit failed: Dimension mismatch: y has 2 elements, X has 1 rows
-> Unexpected? Please report it: https://github.com/DataZooDE/anofox-statistics/issues
```

## Scope of the guards is deliberate

This extension has **258 registration sites and 71 throw sites**. Guarding all of them would create a large review surface for little gain: the internal aggregate combine paths (`Inconsistent feature count`, `Cannot combine states…`) are not something a user invokes directly. The entry points are where a human meets an error, so that is where the link goes.

The guard sits on the **C++ side of the FFI boundary**, so a diagnostic raised in the Rust core keeps its wording and gains the link on the way out — no changes to the Rust crates.

**Errors DuckDB raises before dispatch** (binder, catalog, arity) are left unannotated; they are not ours, and claiming them would send users to the wrong tracker. `feedback.test` pins this.

## Note on the telemetry flag

`DATAZOO_BANNER_TELEMETRY` follows `ANOFOX_TELEMETRY_ENABLED` rather than being forced on — MinGW builds without OpenSSL have no `telemetry.hpp` on the include path, and hardcoding it would break them.

## Verified

- Banner once interactively, silent on repeat, silent when piped
- Error footer present with the Rust-side diagnostic intact
- **2416 assertions in 98 cases pass**, plus the new `feedback.test` (5 assertions)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788615903&installation_model_id=425457&pr_number=127&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F127&signature=4240c6a382e283163d47bf4a7029dc8c3e9272ef485c203b1cf13d2029eba599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->