### PR TITLE
Report the GLM curvature, with the mapping for its rows

### DIFF
--- a/crates/anofox-stats-core/src/models/glm.rs
+++ b/crates/anofox-stats-core/src/models/glm.rs
@@ -434,6 +434,115 @@ mod tests {
     use super::*;
     use crate::types::{PriorSpec, VcovType};
 
+    /// **The GLM curvature is reported, and says which parameter each row is.**
+    ///
+    /// `fit` computes the full covariance on the way to the standard errors and then
+    /// keeps only the diagonal, exactly as the AFT path did before #120. A consumer
+    /// that needs the joint distribution -- a Laplace posterior to sample, a
+    /// prediction interval on a linear combination -- has to rebuild it otherwise.
+    ///
+    /// The mapping is the part that cannot be left implicit. `GlmInferenceResult`'s
+    /// *vectors* are in expanded feature order: the intercept is stripped out
+    /// entirely and a column dropped for rank deficiency comes back as `NaN`. A
+    /// matrix cannot use that convention -- dropping the intercept row would discard
+    /// the intercept/slope covariance, which is most of the reason to want the matrix
+    /// at all. So the matrices are in *fitted* order and `matrix_parameters` says what
+    /// each row is: `None` for the intercept, `Some(j)` for original feature `j`.
+    #[test]
+    fn the_reported_glm_curvature_carries_the_mapping_for_its_rows() {
+        let x = vec![
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+            vec![0.5, 1.5, 1.0, 2.5, 2.0, 3.5, 3.0, 4.5, 4.0, 5.5],
+        ];
+        let y = vec![1.0, 2.0, 4.0, 5.0, 8.0, 10.0, 15.0, 20.0, 25.0, 30.0];
+        let options = PoissonOptions {
+            compute_inference: true,
+            ..Default::default()
+        };
+        let fit = fit_poisson(&y, &x, &options).unwrap();
+        let inf = fit.inference.as_ref().expect("inference was requested");
+        let vcov = inf.vcov.as_ref().expect("the covariance must be reported");
+        let info = inf
+            .information
+            .as_ref()
+            .expect("the observed information must be reported");
+
+        // Intercept first, then both features: three fitted parameters.
+        assert_eq!(inf.matrix_parameters, vec![None, Some(0), Some(1)]);
+        assert_eq!(vcov.nrows(), 3);
+        assert_eq!(info.nrows(), 3);
+
+        // The defining relation, rather than a value.
+        for r in 0..3 {
+            for c in 0..3 {
+                let entry: f64 = (0..3).map(|k| info[(r, k)] * vcov[(k, c)]).sum();
+                let want = if r == c { 1.0 } else { 0.0 };
+                assert!(
+                    (entry - want).abs() < 1e-8,
+                    "(information * vcov)[{r},{c}] = {entry}, expected {want}"
+                );
+            }
+        }
+
+        // And the diagonal reproduces the standard errors already reported, at the
+        // feature index `matrix_parameters` points to -- which is the assertion that
+        // the mapping is right rather than merely present.
+        for (row, slot) in inf.matrix_parameters.iter().enumerate() {
+            if let Some(feature) = slot {
+                assert!(
+                    (vcov[(row, row)].sqrt() - inf.std_errors[*feature]).abs() < 1e-9,
+                    "row {row} maps to feature {feature}: sqrt(vcov) {} vs std_error {}",
+                    vcov[(row, row)].sqrt(),
+                    inf.std_errors[*feature]
+                );
+            }
+        }
+
+        // The off-diagonal is real, so the matrix carries something the diagonal did
+        // not.
+        assert!(
+            vcov[(0, 1)].abs() > 1e-12,
+            "intercept and slope must covary"
+        );
+    }
+
+    /// A column dropped for rank deficiency is absent from the matrices and `NaN` in
+    /// the vectors, and `matrix_parameters` is what reconciles the two.
+    #[test]
+    fn a_dropped_column_leaves_the_curvature_rather_than_appearing_as_a_zero_row() {
+        // The second feature never varies, which is the case the design drops.
+        let col = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+        let x = vec![col.clone(), vec![7.0; 10]];
+        let y = vec![1.0, 2.0, 4.0, 5.0, 8.0, 10.0, 15.0, 20.0, 25.0, 30.0];
+        let options = PoissonOptions {
+            compute_inference: true,
+            ..Default::default()
+        };
+        let fit = fit_poisson(&y, &x, &options).unwrap();
+        let inf = fit.inference.as_ref().expect("inference was requested");
+        let vcov = inf.vcov.as_ref().expect("the covariance must be reported");
+
+        let dropped: Vec<usize> = (0..2).filter(|j| inf.std_errors[*j].is_nan()).collect();
+        assert_eq!(dropped, vec![1], "the constant column is the one dropped");
+
+        // The dropped feature has no row, so a caller cannot index a meaningless one.
+        assert!(
+            !inf.matrix_parameters.contains(&Some(dropped[0])),
+            "a dropped column must not appear in matrix_parameters: {:?}",
+            inf.matrix_parameters
+        );
+        assert_eq!(
+            vcov.nrows(),
+            inf.matrix_parameters.len(),
+            "the matrix is exactly as wide as the mapping says"
+        );
+        for r in 0..vcov.nrows() {
+            for c in 0..vcov.ncols() {
+                assert!(vcov[(r, c)].is_finite(), "no NaN inside the fitted block");
+            }
+        }
+    }
+
     #[test]
     fn test_poisson_basic() {
         let x = vec![vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]];

--- a/crates/anofox-stats-core/src/models/glm_engine/mod.rs
+++ b/crates/anofox-stats-core/src/models/glm_engine/mod.rs
@@ -155,6 +155,17 @@ impl EngineFit {
         let inf = self.inference.as_ref()?;
         let expand = |v: &[f64]| self.design.expand(v).0;
 
+        // What each row of the matrices is. The vectors above are expanded into the
+        // original feature order with `NaN` for dropped columns and the intercept
+        // stripped; the matrices stay in fitted order, so this is what reconciles the
+        // two. A dropped column is absent rather than present-and-`NaN`, so a caller
+        // cannot index a row that was never fitted.
+        let mut matrix_parameters: Vec<Option<usize>> = Vec::new();
+        if self.design.fit_intercept {
+            matrix_parameters.push(None);
+        }
+        matrix_parameters.extend(self.design.retained_columns.iter().map(|&j| Some(j)));
+
         Some(GlmInferenceResult {
             std_errors: expand(&inf.std_errors),
             z_values: expand(&inf.z_values),
@@ -162,6 +173,9 @@ impl EngineFit {
             ci_lower: expand(&inf.ci_lower),
             ci_upper: expand(&inf.ci_upper),
             confidence_level: inf.confidence_level,
+            vcov: Some(inf.vcov.clone()),
+            information: Some(self.irls.information.clone()),
+            matrix_parameters,
         })
     }
 }

--- a/crates/anofox-stats-core/src/types.rs
+++ b/crates/anofox-stats-core/src/types.rs
@@ -1,3 +1,5 @@
+use faer::Mat;
+
 /// Core result from model fitting - always computed
 #[derive(Debug, Clone)]
 pub struct FitResultCore {
@@ -911,6 +913,28 @@ pub struct GlmInferenceResult {
     pub ci_upper: Vec<f64>,
     /// Confidence level used (e.g., 0.95)
     pub confidence_level: f64,
+    /// The full covariance of the fitted parameters at the mode, `None` when
+    /// inference was not requested.
+    ///
+    /// **In fitted order, not the expanded feature order the vectors above use.**
+    /// The vectors strip the intercept and put `NaN` where a column was dropped for
+    /// rank deficiency; a matrix cannot follow that convention, because removing the
+    /// intercept row would discard the intercept/slope covariance that is most of the
+    /// reason to want the matrix. [`Self::matrix_parameters`] says what each row is.
+    pub vcov: Option<Mat<f64>>,
+    /// The penalised observed information at the mode — the inverse of [`Self::vcov`]
+    /// — in the same order, `None` when inference was not requested.
+    ///
+    /// Reported alongside the covariance because they answer different questions:
+    /// `vcov` is what a report reads, the information is what a sampler factorises to
+    /// draw from the Laplace approximation.
+    pub information: Option<Mat<f64>>,
+    /// What each row and column of [`Self::vcov`] and [`Self::information`] refers to:
+    /// `None` for the intercept, `Some(j)` for feature `j` of the *original* design.
+    ///
+    /// Dropped columns are absent rather than present-and-`NaN`, so a caller cannot
+    /// index a row that was never fitted.
+    pub matrix_parameters: Vec<Option<usize>>,
 }
 
 // ============================================================================


### PR DESCRIPTION
`fit` computes the full covariance on the way to the standard errors and then keeps only the diagonal — exactly what the AFT path did before #120. A consumer needing the joint distribution has to rebuild it, re-differentiating a likelihood this crate has already differentiated.

## Why now

This is the enabler for bridging `fit_negbinomial` and `fit_gamma` into a Bayesian draws contract. `anofox-bayes` has **no family** for an ungrouped count or positive-continuous GLM — its native hierarchical ones require a `group` and refuse a single one (measured: a 200-row count regression through `hier_negbin` with one group returns `insufficient_data`). Those two bridges are what fill the hole, and they need this first.

## The mapping, which is why this is not a copy of #126

`GlmInferenceResult`'s **vectors** are in expanded feature order: the intercept is stripped out entirely, and a column dropped for being constant comes back as `NaN`.

A matrix cannot follow that convention — removing the intercept row would discard the intercept/slope covariance, which is most of the reason to want the matrix at all.

So `vcov` and `information` stay in **fitted** order, and `matrix_parameters` says what each row is: `None` for the intercept, `Some(j)` for original feature `j`. A dropped column is **absent** rather than present-and-`NaN`, so a caller cannot index a row that was never fitted.

Leaving that implicit would have been a silent mis-indexing waiting to happen, which is why it is a field rather than a doc comment.

## Tests — both red first

**`the_reported_glm_curvature_carries_the_mapping_for_its_rows`**
- `information × vcov = I` to 1e-8 — the defining relation, not a value
- `matrix_parameters == [None, Some(0), Some(1)]`
- each mapped diagonal reproduces the standard error already reported **at the feature index the mapping points to** — this is what checks the mapping is *right* rather than merely present
- the off-diagonal is non-zero, so the matrix carries something the diagonal did not

**`a_dropped_column_leaves_the_curvature_rather_than_appearing_as_a_zero_row`**
- a constant column is dropped, appears as `NaN` in the vectors, and is **missing** from `matrix_parameters`
- the matrix is exactly as wide as the mapping claims
- nothing inside the fitted block is `NaN`

## Verification

`cargo test -p anofox-stats-core --lib` — **289 pass** · `make test` — 2416 assertions in 98 cases · `cargo fmt --all --check` clean · clippy clean · workspace builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788669410&installation_model_id=425457&pr_number=128&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F128&signature=b36e2b98f43cf33596e1a34eb9da2618917643621768bcfd935f5c62ad9e5c04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->