### PR TITLE
fix(ci): force the tag fetch in the deploy workflow

### DIFF
--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -138,11 +138,11 @@ jobs:
           python3 -m pip install pip awscli
           git config --global --add safe.directory '*'
           cd duckdb
-          git fetch --tags
-          export DUCKDB_VERSION=`git tag --points-at HEAD`
+          git fetch --tags --force
+          export DUCKDB_VERSION=`git tag --points-at HEAD | head -1`
           export DUCKDB_VERSION=${DUCKDB_VERSION:=`git log -1 --format=%h`}
           cd ..
-          git fetch --tags
-          export EXT_VERSION=`git tag --points-at HEAD`
+          git fetch --tags --force
+          export EXT_VERSION=`git tag --points-at HEAD | head -1`
           export EXT_VERSION=${EXT_VERSION:=`git log -1 --format=%h`}
           ${{ inputs.deploy_script }} ${{ inputs.extension_name }} $EXT_VERSION $DUCKDB_VERSION ${{ matrix.duckdb_arch }} $BUCKET_NAME ${{inputs.deploy_latest || 'true' && 'false'}} ${{inputs.deploy_versioned || 'true' && 'false'}}


### PR DESCRIPTION
Release tags pushed here fail to deploy — the tag exists but ships no binaries.

`actions/checkout` fetches the annotated tag, then the deploy step's `git fetch --tags` refuses to touch the same ref:

```
! [rejected] v2026.08.07 -> v2026.08.07 (would clobber existing tag)
```

The first deploy job to hit it exits 1, and `fail-fast` cancels every sibling — so **no architecture uploads**, not just the one that failed.

## Why this repo and not others

This repo carries a **vendored copy** of `_extension_deploy.yml` predating the fix. Across the fleet the split is exact:

| Deploy workflow | Tag deploy |
|---|---|
| `git fetch --tags --force` — erpl-tunnel, anofox-tabfm, anofox-forecast, anofox-bayes | ✅ |
| no local copy, uses upstream — anofox-similarity, anofox-inventory | ✅ |
| plain `git fetch --tags` — this repo, erpl, erpl-idoc, duckdb-gdrive, anofox-scenario, anofox-tabular, anofox-context | ❌ |

Deterministic, and ours to fix — not upstream's bug and not a race. Deleting and re-pushing the tag does **not** help (verified on anofox-scenario): the tag was never the problem, and `--force` is precisely the flag that lets fetch update a ref `actions/checkout` already placed.

Needed before this repo can cut a release that actually publishes binaries.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/DataZooDE/codesmith/anofox-statistics/pr/129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788753692&installation_model_id=425457&pr_number=129&repository=DataZooDE%2Fanofox-statistics&return_to=https%3A%2F%2Fgithub.com%2FDataZooDE%2Fanofox-statistics%2Fpull%2F129&signature=b26c89ed0040e71c852dcbe78fe05d1c6b51aab7369e3aa73b9b8dbc6f291d56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->